### PR TITLE
Multicam Refinements + GigE Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ config = {
 grabber = FrameGrabber.create_grabber(config)
 
 ```
-`config` can contain many details and settings about your camera, but only `input_type` is required. Available `input_type` options are: `webcam`, `rtsp`, `realsense` and `basler_usb`.
+`config` can contain many details and settings about your camera, but only `input_type` is required. Available `input_type` options are: `webcam`, `rtsp`, `realsense` and `basler`.
 
 Here's an example of a single webcam configured with several options:
 ```
@@ -141,7 +141,31 @@ for grabber in grabbers.values():
     display_image(frame)
     grabber.release()
 ```
-It is also possible to 'autodiscover' cameras. This will automatically connect to all cameras that are plugged into your machine, such as `webcam`, `realsense` and `basler_usb` cameras. Default configurations will be loaded for each camera. Please note that RTSP streams cannot be discovered in this manner; RTSP URLs must be specified in the configurations.
+### Options
+The table below shows all available options, and the cameras to which they apply.
+| Configuration Name          | Example         | Webcam   | RTSP     | Basler   | Realsense |
+|-----------------------------|-----------------|----------|----------|----------|-----------|
+| name                        | On robot arm    | optional | optional | optional | optional  |
+| input_type                  | webcam          | **required** | **required** | **required** | **required** |
+| id.serial_number            | 23458234        | optional | -        | optional | optional  |
+| id.rtsp_url                 | rtsp://...      | -        | required | -        | -         |
+| options.resolution.height   | 480             | optional | -        | optional | optional  |
+| options.resolution.width    | 640             | optional | -        | optional | optional  |
+| options.zoom.digital        | 1.3             | optional | optional | optional | optional  |
+| options.crop.pixels.top     | 100             | optional | optional | optional | optional  |
+| options.crop.pixels.bottom  | 400             | optional | optional | optional | optional  |
+| options.crop.pixels.left    | 100             | optional | optional | optional | optional  |
+| options.crop.pixels.right   | 400             | optional | optional | optional | optional  |
+| options.crop.relative.top   | 0.1             | optional | optional | optional | optional  |
+| options.crop.relative.bottom| 0.9             | optional | optional | optional | optional  |
+| options.crop.relative.left  | 0.1             | optional | optional | optional | optional  |
+| options.crop.relative.right | 0.9             | optional | optional | optional | optional  |
+| options.depth.side_by_side  | 1               | -        | -        | -        | optional  |
+| options.pixel_format        | RGB8            | -        | -        | optional | -         |
+| options.exposure_us         | 60000           | -        | -        | optional | -         |
+
+### Autodiscovery
+It is also possible to 'autodiscover' cameras. This will automatically connect to all cameras that are plugged into your machine, such as `webcam`, `realsense` and `basler` cameras. Default configurations will be loaded for each camera. Please note that RTSP streams cannot be discovered in this manner; RTSP URLs must be specified in the configurations.
 ```
 grabbers = FrameGrabber.autodiscover()
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use a Basler USB or GigE camera, you must separately install the `pypylon` pa
 
 Similarly, to use Intel RealSense cameras, you must install `pyrealsense2`. 
 
-If you don't intend to use these camera types, you don't need to install any of these extra packages. 
+If you don't intend to use these camera types, you don't need to install these extra packages. 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ GL_CAMERAS: |
           right: .8
   - name: conference room
       input_type: rtsp
-      address: 
+      id: 
         rtsp_url: rtsp://admin:password@192.168.1.20/cam/realmonitor?channel=1&subtype=0
       options:
         crop:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ pip install framegrab
 ```
 
 ## Optional Dependencies
-To use a Basler USB or GigE camera, you must separately install the pypylon package.
+To use a Basler USB or GigE camera, you must separately install the `pypylon` package.
 
-Similarly, to use Intel RealSense cameras, you must install pyrealsense2. 
+Similarly, to use Intel RealSense cameras, you must install `pyrealsense2`. 
 
 If you don't intend to use these camera types, you don't need to install any of these extra packages. 
 
@@ -45,7 +45,7 @@ grabber = FrameGrabber.create_grabber(config)
 ```
 `config` can contain many details and settings about your camera, but only `input_type` is required. Available `input_type` options are: `generic_usb`, `rtsp`, `realsense` and `basler`.
 
-Here's an example of a single webcam configured with several options:
+Here's an example of a single USB camera configured with several options:
 ```
 config = {
     'name': 'Front Door Camera',
@@ -99,7 +99,7 @@ grabber.release()
 
 You might have several cameras that you want to use in the same application. In this case, you can load the configurations from a yaml file and use `FrameGrabber.create_grabbers`.
 
-If you have multiple cameras of the same type plugged in, it's recommended to provide serial numbers in the configurations; this ensures that each configuration is paired with the correct camera. If you don't provide serial numbers in your configurations, configurations will be paired with cameras in a sequential manner.
+If you have multiple cameras of the same type plugged in, it's recommended that you include serial numbers in the configurations; this ensures that each configuration is paired with the correct camera. If you don't provide serial numbers in your configurations, configurations will be paired with cameras in a sequential manner.
 
 Below is a sample yaml file containing configurations for three different cameras.
 ```
@@ -148,8 +148,8 @@ for grabber in grabbers.values():
     display_image(frame) # substitute this line for your preferred method for displaying images, such as cv2.imshow
     grabber.release()
 ```
-### Options
-The table below shows all available options, and the cameras to which they apply.
+### Configurations
+The table below shows all available configurations and the cameras to which they apply.
 | Configuration Name         | Example         | Webcam     | RTSP      | Basler    | Realsense |
 |----------------------------|-----------------|------------|-----------|-----------|-----------|
 | name                       | On Robot Arm    | optional   | optional  | optional  | optional  |
@@ -169,9 +169,10 @@ The table below shows all available options, and the cameras to which they apply
 | options.crop.relative.right | 0.9            | optional   | optional  | optional  | optional  |
 | options.depth.side_by_side | 1              | -          | -         | -         | optional  |
 
+In addition to the configurations in the table above, you can set any Basler camera property by including `options.basler.<BASLER PROPERTY NAME>`. For example, it's common to set `options.basler.PixelFormat` to `RGB8`.
 
 ### Autodiscovery
-It is also possible to 'autodiscover' cameras. This will automatically connect to all cameras that are plugged into your machine, including `generic_usb`, `realsense` and `basler` cameras. Default configurations will be loaded for each camera. Please note that RTSP streams cannot be discovered in this manner; RTSP URLs must be specified in the configurations.
+Autodiscovery automatically connects to all cameras that are plugged into your machine or discoverable on the network, including `generic_usb`, `realsense` and `basler` cameras. Default configurations will be loaded for each camera. Please note that RTSP streams cannot be discovered in this manner; RTSP URLs must be specified in the configurations.
 
 Autodiscovery is great for simple applications where you don't need to set any special options on your cameras. It's also a convenient method for finding the serial numbers of your cameras (if the serial number isn't printed on the camera).
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FrameGrab by Groundlight
 ## A user-friendly library for grabbing images from cameras or streams
 
-FrameGrab is an open-source Python library designed to make it easy to grab frames (images) from cameras or streams. The library supports webcams, RTSP streams, Basler USB cameras and Intel RealSense depth cameras.
+FrameGrab is an open-source Python library designed to make it easy to grab frames (images) from cameras or streams. The library supports generic USB cameras (such as webcams), RTSP streams, Basler USB cameras, Basler GigE cameras, and Intel RealSense depth cameras.
 
 FrameGrab also provides basic motion detection functionality. FrameGrab requires Python 3.7 or higher.
 
@@ -20,29 +20,36 @@ To install the FrameGrab library, simply run:
 pip install framegrab
 ```
 
+## Optional Dependencies
+To use a Basler USB or GigE camera, you must separately install the pypylon package.
+
+Similarly, to use Intel RealSense cameras, you must install pyrealsense2. 
+
+If you don't intend to use these camera types, you don't need to install any of these extra packages. 
+
 ## Usage
 
 ### Frame Grabbing
 
-Simple usage with a single webcam would look something like the following:
+Simple usage with a single USB camera would look something like the following:
 
 ```
 from framegrab import FrameGrabber
 
 config = {
-    'input_type': 'webcam',
+    'input_type': 'generic_usb',
 }
 
 grabber = FrameGrabber.create_grabber(config)
 
 ```
-`config` can contain many details and settings about your camera, but only `input_type` is required. Available `input_type` options are: `webcam`, `rtsp`, `realsense` and `basler`.
+`config` can contain many details and settings about your camera, but only `input_type` is required. Available `input_type` options are: `generic_usb`, `rtsp`, `realsense` and `basler`.
 
 Here's an example of a single webcam configured with several options:
 ```
 config = {
-    'name': 'front door camera',
-    'input_type': 'webcam',
+    'name': 'Front Door Camera',
+    'input_type': 'generic_usb',
     'id': {
         'serial_number': 23432570
     },
@@ -111,13 +118,13 @@ GL_CAMERAS: |
         rtsp_url: rtsp://admin:password@192.168.1.20/cam/realmonitor?channel=1&subtype=0
       options:
         crop:
-          absolute:
+          pixels:
             top: 350
             bottom: 1100
             left: 1100
             right: 2000
   - name: workshop
-    input_type: webcam
+    input_type: generic_usb
     id:
       serial_number: B77D3A8F
 ```
@@ -138,36 +145,43 @@ grabbers = FrameGrabber.create_grabbers(configs)
 for grabber in grabbers.values():
     print(grabber.config)
     frame = grabber.grab()
-    display_image(frame)
+    display_image(frame) # substitute this line for your preferred method for displaying images, such as cv2.imshow
     grabber.release()
 ```
 ### Options
 The table below shows all available options, and the cameras to which they apply.
-| Configuration Name          | Example         | Webcam   | RTSP     | Basler   | Realsense |
-|-----------------------------|-----------------|----------|----------|----------|-----------|
-| name                        | On robot arm    | optional | optional | optional | optional  |
-| input_type                  | webcam          | **required** | **required** | **required** | **required** |
-| id.serial_number            | 23458234        | optional | -        | optional | optional  |
-| id.rtsp_url                 | rtsp://...      | -        | required | -        | -         |
-| options.resolution.height   | 480             | optional | -        | optional | optional  |
-| options.resolution.width    | 640             | optional | -        | optional | optional  |
-| options.zoom.digital        | 1.3             | optional | optional | optional | optional  |
-| options.crop.pixels.top     | 100             | optional | optional | optional | optional  |
-| options.crop.pixels.bottom  | 400             | optional | optional | optional | optional  |
-| options.crop.pixels.left    | 100             | optional | optional | optional | optional  |
-| options.crop.pixels.right   | 400             | optional | optional | optional | optional  |
-| options.crop.relative.top   | 0.1             | optional | optional | optional | optional  |
-| options.crop.relative.bottom| 0.9             | optional | optional | optional | optional  |
-| options.crop.relative.left  | 0.1             | optional | optional | optional | optional  |
-| options.crop.relative.right | 0.9             | optional | optional | optional | optional  |
-| options.depth.side_by_side  | 1               | -        | -        | -        | optional  |
-| options.pixel_format        | RGB8            | -        | -        | optional | -         |
-| options.exposure_us         | 60000           | -        | -        | optional | -         |
+| Configuration Name         | Example         | Webcam     | RTSP      | Basler    | Realsense |
+|----------------------------|-----------------|------------|-----------|-----------|-----------|
+| name                       | On Robot Arm    | optional   | optional  | optional  | optional  |
+| input_type                 | generic_usb    | required   | required  | required  | required  |
+| id.serial_number           | 23458234       | optional   | -         | optional  | optional  |
+| id.rtsp_rul                | rtsp://…        | -          | required  | -         | -         |
+| options.resolution.height  | 480            | optional   | -         | -         | optional  |
+| options.resolution.width   | 640            | optional   | -         | -         | optional  |
+| options.zoom.digital       | 1.3            | optional   | optional  | optional  | optional  |
+| options.crop.pixels.top    | 100            | optional   | optional  | optional  | optional  |
+| options.crop.pixels.bottom | 400            | optional   | optional  | optional  | optional  |
+| options.crop.pixels.left   | 100            | optional   | optional  | optional  | optional  |
+| options.crop.pixels.right  | 400            | optional   | optional  | optional  | optional  |
+| options.crop.relative.top  | 0.1            | optional   | optional  | optional  | optional  |
+| options.crop.relative.bottom | 0.9          | optional   | optional  | optional  | optional  |
+| options.crop.relative.left | 0.1            | optional   | optional  | optional  | optional  |
+| options.crop.relative.right | 0.9            | optional   | optional  | optional  | optional  |
+| options.depth.side_by_side | 1              | -          | -         | -         | optional  |
+
 
 ### Autodiscovery
-It is also possible to 'autodiscover' cameras. This will automatically connect to all cameras that are plugged into your machine, such as `webcam`, `realsense` and `basler` cameras. Default configurations will be loaded for each camera. Please note that RTSP streams cannot be discovered in this manner; RTSP URLs must be specified in the configurations.
+It is also possible to 'autodiscover' cameras. This will automatically connect to all cameras that are plugged into your machine, including `generic_usb`, `realsense` and `basler` cameras. Default configurations will be loaded for each camera. Please note that RTSP streams cannot be discovered in this manner; RTSP URLs must be specified in the configurations.
+
+Autodiscovery is great for simple applications where you don't need to set any special options on your cameras. It's also a convenient method for finding the serial numbers of your cameras (if the serial number isn't printed on the camera).
 ```
 grabbers = FrameGrabber.autodiscover()
+
+# Print some information about the discovered cameras
+for grabber in grabbers.values():
+    print(grabber.config)
+
+    grabber.release()
 ```
 
 ### Motion Detection

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -277,7 +277,7 @@ class WebcamFrameGrabber(FrameGrabber):
 
         # Find the serial number of connected webcams. Currently only works on Linux.
         if OPERATING_SYSTEM == "Linux":
-            found_webcams = WebcamFrameGrabber._find_webcam_devnames()
+            found_webcams = WebcamFrameGrabber._find_webcam_serial_numbers()
         else:
             found_webcams = {}
 
@@ -343,9 +343,9 @@ class WebcamFrameGrabber(FrameGrabber):
         self.capture.set(cv2.CAP_PROP_BUFFERSIZE, 1)
 
     @staticmethod
-    def _find_webcam_devnames() -> dict:
-        """Finds all plugged in webcams and returns a dictionary mapping device names to
-        to serial numbers. This is useful for connecting the dots between user provided configurations
+    def _find_webcam_serial_numbers() -> dict:
+        """Finds all plugged in webcams and returns a dictionary mapping serial_numbers to details about the device.
+        This is useful for connecting the dots between user provided configurations
         and actual plugged in devices.
 
         This function only works on Linux, and was specifically tested on an Nvidia Jetson.

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -11,7 +11,6 @@ import cv2
 import numpy as np
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO) # not sure if this is the right long-term solution
 
 # Optional imports
 try:
@@ -260,8 +259,6 @@ class FrameGrabber(ABC):
         camera-specific options.
         """
 
-        self.config['options'] = options
-
         # Ensure that the user hasn't provided pixel cropping parameters and relative cropping parameters
         pixel_crop_params = options.get("crop", {}).get("pixels", {})
         relative_crop_params = options.get("crop", {}).get("relative", {})
@@ -291,6 +288,9 @@ class FrameGrabber(ABC):
 
         # Apply camera specific options
         self._apply_camera_specific_options(options)
+
+        # Save the options to the config
+        self.config['options'] = options
 
     @abstractmethod
     def _apply_camera_specific_options(options: dict) -> None:


### PR DESCRIPTION
What's new is listed below:

Basler
- [x] Support for Basler GigE cameras. GigE cameras are supported through the pypylon module in much the same way Basler USB cameras are. The users just needs to user the Pylon Viewer software provided by Basler (available for Windows and Linux) to configure their GigE camera on the network. Once this is done, pypylon can discover the GigE camera by serial number.
- [x] All Basler properties can now be set. In options.basler.<BASLER PROPERTY NAME>, specify a valid basler property and it will be set. Available properties depend on camera model, and if you specify an invalid property, a Basler exception will be raised.

Intel Realsense
- [x] Resolution can be changed (options.resolution.height and options.resolution.width). This wasn’t functional in the previous release, because realsense handles resolution in a different manner than other cameras. 

RTSP
- [x] The frame rate of RTSP streams has been dramatically improved by adding time.sleep() in the _drain_buffer thread
- [x] The name of the configuration for RTSP URLs has changed from address.rtsp_url to id.rtsp_url per Leo’s suggestion
- [x] Cv2.set_resolution call removed from RTSP since I learned that this does not work on RTSP feeds. An exception is now raised if the user tries to set a resolution on RTSP feed

General
- [x] When connecting to a camera without providing a serial_number (running FrameGrabber.autodiscover is a good example of this), the serial number will be added to the configuration. This can help users figure out the serial numbers of their cameras. The readme was updated with this info.
- [x] Units of measurement have been added to some configuration names: e.g. options.crop.absolute -> options.crop.pixels. 
- [x] Crop absolute and crop relative are now treated as mutually exclusive, since it doesn’t make sense to use both, on the same camera. If the user tries to use both, an exception will be raised.
- [x] Bug fix: previously if the user called FrameGrabber.create_grabbers and one or more camera configs lacked a ‘name’, a KeyError was raised. This now functions as intended and a name will be generated for any camera without a user-provided name. The default name for cameras has also changed from ‘Unnamed Camera n (input_type)’ to ‘Camera n (input_type)’, which seems a little more user-friendly.
- [x] If any of the optional dependencies (pypylon or pyrealsense2) fail to import, a warning is logged, which included the import exception, in case it is useful to the user
- [x] An exception is now raised if duplicate camera names are provided. Camera names are treated as unique keys to refer to a FrameGrabber object, so raising this exception helps the user from getting into trouble.
- [x] Updated documentation for autodiscover 
- [x] Readme updated to include a chart with the all the options