### PR TITLE
adding handling for autodiscover when no cameras are plugged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ for grabber in grabbers.values():
 ```
 ### Configurations
 The table below shows all available configurations and the cameras to which they apply.
-| Configuration Name         | Example         | Webcam     | RTSP      | Basler    | Realsense |
+| Configuration Name         | Example         | Generic USB     | RTSP      | Basler    | Realsense |
 |----------------------------|-----------------|------------|-----------|-----------|-----------|
 | name                       | On Robot Arm    | optional   | optional  | optional  | optional  |
 | input_type                 | generic_usb    | required   | required  | required  | required  |
@@ -242,6 +242,6 @@ We welcome contributions to FrameGrab! If you would like to contribute, please f
 
 ## License
 
-FrameGrab is released under the MIT License. For more information, please refer to the [LICENSE](LICENSE) file.
+FrameGrab is released under the MIT License. For more information, please refer to the [LICENSE.txt](LICENSE.txt) file.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.3.1"
+version = "0.3.2"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -469,7 +469,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, _ = process.communicate()
 
-        if len(stdout) == 0: # len is zero when no cameras are plugged in
+        if len(stdout) == 0:  # len is zero when no cameras are plugged in
             device_paths = []
         else:
             output = stdout.decode("utf-8")

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -478,7 +478,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
         found_cams = []
         for device_path in device_paths:
             # ls -l /sys/class/video4linux/video0/device returns a path that points back into the /sys/bus/usb/devices/
-            # directory where can determine the serial number.
+            # directory where we can determine the serial number.
             # e.g. /sys/bus/usb/devices/2-3.2:1.0 -> /sys/bus/usb/devices/<bus>-<port>.<subport>:<config>.<interface>
             devname = device_path.split("/")[-1]
             command = f"ls -l /sys/class/video4linux/{devname}/device"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -468,15 +468,19 @@ class GenericUSBFrameGrabber(FrameGrabber):
         command = "ls /dev/video*"
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, _ = process.communicate()
-        output = stdout.decode("utf-8")
-        devices = output.strip().split("\n")
+
+        if len(stdout) == 0: # len is zero when no cameras are plugged in
+            device_paths = []
+        else:
+            output = stdout.decode("utf-8")
+            device_paths = output.strip().split("\n")
 
         found_cams = []
-        for devpath in devices:
+        for device_path in device_paths:
             # ls -l /sys/class/video4linux/video0/device returns a path that points back into the /sys/bus/usb/devices/
             # directory where can determine the serial number.
             # e.g. /sys/bus/usb/devices/2-3.2:1.0 -> /sys/bus/usb/devices/<bus>-<port>.<subport>:<config>.<interface>
-            devname = devpath.split("/")[-1]
+            devname = device_path.split("/")[-1]
             command = f"ls -l /sys/class/video4linux/{devname}/device"
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             stdout, _ = process.communicate()
@@ -496,7 +500,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
                 found_cams.append(
                     {
                         "serial_number": serial_number,
-                        "devname": f"/dev/{devname}",
+                        "device_path": device_path,
                         "idx": idx,
                     }
                 )


### PR DESCRIPTION
**Background:**
https://positronixcorp.atlassian.net/browse/PK-2140
When creating grabbers on a Linux machine, framegrab attempts to find the serial numbers of the plugged in devices by running some terminal commands via Python. This is done in GenericUSBFrameGrabber._find_cameras. If no devices are plugged in, the program crashes.

Need to add some better error handling for this situation.

Steps to reproduce, on a Linux machine (e.g. Jetson) that does not have any cameras plugged in, run `ls /dev/video*`. You will get an error. In the Python code, this ends up causing an exception to be raised on this line `idx = int(re.findall(r"\d+", devname)[-1])`

**Solution:**
Now when no cameras are plugged in, FrameGrabber.autodiscover returns an empty dictionary



