### PR TITLE
Fixing threading error when exiting program with ctrl+c

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.4.3"
+version = "0.4.4"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -663,7 +663,7 @@ class RTSPFrameGrabber(FrameGrabber):
         # This allows the program to exit gracefully when the user presses Ctrl+C.
         # Daemon threads cannot perform clean up operations when they are terminated, but this is okay because the only
         # cleanup we need is to terminate the thread that drains the buffer.
-        thread.daemon = True 
+        thread.daemon = True
         thread.start()
 
     def grab(self) -> np.ndarray:

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -658,7 +658,13 @@ class RTSPFrameGrabber(FrameGrabber):
         # feed, so we will assume a high FPS of 60.
         self.drain_rate = 1 / 60
 
-        Thread(target=self._drain).start()
+        thread = Thread(target=self._drain)
+        # Setting thread to daemon mode means it will automatically terminate when the main thread terminates.
+        # This allows the program to exit gracefully when the user presses Ctrl+C.
+        # Daemon threads cannot peform clean up operations when they are terminated, but this is okay because the only
+        # cleanup we need is to terminate the thread that drains the buffer
+        thread.daemon = True 
+        thread.start()
 
     def grab(self) -> np.ndarray:
         with self.lock:
@@ -686,6 +692,7 @@ class RTSPFrameGrabber(FrameGrabber):
         This keeps the buffer empty so that when we actually want to read a frame,
         we can get the most current one.
         """
+
         while self.run:
             with self.lock:
                 _ = self.capture.grab()

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -661,8 +661,8 @@ class RTSPFrameGrabber(FrameGrabber):
         thread = Thread(target=self._drain)
         # Setting thread to daemon mode means it will automatically terminate when the main thread terminates.
         # This allows the program to exit gracefully when the user presses Ctrl+C.
-        # Daemon threads cannot peform clean up operations when they are terminated, but this is okay because the only
-        # cleanup we need is to terminate the thread that drains the buffer
+        # Daemon threads cannot perform clean up operations when they are terminated, but this is okay because the only
+        # cleanup we need is to terminate the thread that drains the buffer.
         thread.daemon = True 
         thread.start()
 


### PR DESCRIPTION
Previously, if an RTSP FrameGrabber object was running in your script, you would get a threading error if you tried to terminate the script with crtl+c.

This PR adds handling to avoid this error and exit gracefully. 