### PR TITLE
CLI improvements - autodiscover previews images, is more robust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.4.4"
+version = "0.4.5"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/cli/autodiscover.py
+++ b/src/framegrab/cli/autodiscover.py
@@ -37,7 +37,7 @@ def autodiscover(preview: str):
 
             click.echo(f"Grabbed sample frame from {camera_name} with shape {frame.shape}", err=True)
             click.echo(grabber.config, err=True)
-            preview_image(camera_name, frame, preview)
+            preview_image(frame, camera_name, preview)
 
             grabber.release()
         except Exception:

--- a/src/framegrab/cli/autodiscover.py
+++ b/src/framegrab/cli/autodiscover.py
@@ -1,8 +1,8 @@
 import traceback
 
 import click
-from imgcat import imgcat
 import yaml
+from imgcat import imgcat
 
 from framegrab import FrameGrabber
 from framegrab.cli.clitools import PREVIEW_COMMAND_CHOICES, preview_image
@@ -14,7 +14,7 @@ from framegrab.cli.clitools import PREVIEW_COMMAND_CHOICES, preview_image
     type=click.Choice(PREVIEW_COMMAND_CHOICES, case_sensitive=False),
     default="imgcat",
 )
-def autodiscover(preview:str):
+def autodiscover(preview: str):
     """Automatically discover cameras connected to the current host (e.g. USB)."""
     # Print message to stderr
     click.echo("Discovering cameras...", err=True)

--- a/src/framegrab/cli/clitools.py
+++ b/src/framegrab/cli/clitools.py
@@ -43,12 +43,12 @@ _PREVIEW_COMMANDS = {
 PREVIEW_COMMAND_CHOICES = list(_PREVIEW_COMMANDS.keys())
 
 
-def preview_image(name: str, frame, output_type: str):
+def preview_image(frame, title: str, output_type: str):
     """Displays the given frame using the given output method."""
     if output_type not in PREVIEW_COMMAND_CHOICES:
         raise ValueError(f"Invalid output method: {output_type}.  Valid options are {PREVIEW_COMMAND_CHOICES}.")
     command = _PREVIEW_COMMANDS[output_type]
     if frame is None:
-        print(f"Trying to preview None frame from {name}.")
+        print(f"Trying to preview None frame from {title}.")
         return
-    command(name, frame)
+    command(title, frame)

--- a/src/framegrab/cli/clitools.py
+++ b/src/framegrab/cli/clitools.py
@@ -18,6 +18,7 @@ def cv2_preview(name: str, frame):
     _ = cv2.waitKey(0)
     cv2.destroyAllWindows()
 
+
 def ascii_preview(name: str, frame):
     """Displays the given frame in the terminal using ascii art."""
     columns, _ = shutil.get_terminal_size()
@@ -26,17 +27,18 @@ def ascii_preview(name: str, frame):
     out = ascii_magic.from_pillow_image(pil_image)
     out.to_terminal(columns=columns)
 
+
 def null_preview(name: str, frame):
     """Does nothing."""
     pass
 
 
 _PREVIEW_COMMANDS = {
-        "imgcat": imgcat_preview,
-        "cv2": cv2_preview,
-        "ascii": ascii_preview,
-        "none": null_preview,
-    }
+    "imgcat": imgcat_preview,
+    "cv2": cv2_preview,
+    "ascii": ascii_preview,
+    "none": null_preview,
+}
 
 PREVIEW_COMMAND_CHOICES = list(_PREVIEW_COMMANDS.keys())
 

--- a/src/framegrab/cli/preview.py
+++ b/src/framegrab/cli/preview.py
@@ -48,7 +48,7 @@ def preview(config: str, output: str):
                 print(f"Failed to grab preview frame from {camera_name}.")
                 continue
             print(f"Grabbed preview frame from {camera_name}")
-            preview_command(camera_name, frame)
+            preview_image(frame, camera_name, output)
     finally:
         for grabber in grabbers.values():
             try:

--- a/src/framegrab/cli/preview.py
+++ b/src/framegrab/cli/preview.py
@@ -1,4 +1,5 @@
 import shutil
+import traceback
 
 import ascii_magic
 import click
@@ -66,9 +67,13 @@ def preview(config: str, output: str):
     try:
         # Get a frame from each camera
         for camera_name, grabber in grabbers.items():
-            frame = grabber.grab()
-            print(f"Grabbed frame from {camera_name}")
-            preview_command(camera_name, frame)
+            try:
+                frame = grabber.grab()
+                print(f"Grabbed frame from {camera_name}")
+                preview_command(camera_name, frame)
+            except Exception as e:
+                print(f"Failed to grab frame from {camera_name}: {e}")
+                traceback.print_exc()
     finally:
         for grabber in grabbers.values():
             try:

--- a/src/framegrab/cli/preview.py
+++ b/src/framegrab/cli/preview.py
@@ -39,14 +39,15 @@ def preview(config: str, output: str):
         for camera_name, grabber in grabbers.items():
             try:
                 frame = grabber.grab()
-                if frame is None:
-                    print(f"Failed to grab frame from {camera_name}.")
-                    continue
-                print(f"Grabbed frame from {camera_name}")
-                preview_command(camera_name, frame)
             except Exception as e:
-                print(f"Failed to grab frame from {camera_name}: {e}")
+                print(f"Error grabbing preview frame from {camera_name}: {e}")
                 traceback.print_exc()
+                continue
+            if frame is None:
+                print(f"Failed to grab preview frame from {camera_name}.")
+                continue
+            print(f"Grabbed preview frame from {camera_name}")
+            preview_command(camera_name, frame)
     finally:
         for grabber in grabbers.values():
             try:

--- a/src/framegrab/cli/preview.py
+++ b/src/framegrab/cli/preview.py
@@ -11,6 +11,7 @@ from PIL import Image
 from framegrab import FrameGrabber
 from framegrab.cli.clitools import PREVIEW_COMMAND_CHOICES, preview_image
 
+
 def get_image_sources_from_config(config: str) -> list:
     """Returns a dictionary of image sources from the given configuration file."""
     with open(config, "r") as f:


### PR DESCRIPTION
A bit of refactoring in the CLI tools for preview & autodiscover so they're more robust and useful.  Autodiscover will preview the images it finds with `imgcat` by default.