### PR TITLE
handle edge case

### DIFF
--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -672,6 +672,9 @@ class RTSPFrameGrabber(FrameGrabber):
             if not ret:
                 logger.error(f"Could not read frame from {self.capture}")
 
+        if frame is None:
+            camera_name = self.config.get("name", "Unnamed RTSP Stream")
+            raise ValueError(f"Could not grab a frame from {camera_name}. Is the RTSP stream connected?")
         frame = self._process_frame(frame)
 
         return frame


### PR DESCRIPTION
Not an incredibly big change, but we got uninformative errors on some rtsp streams that seemingly connect but won't supply any data stream. We could alternatively provide a stronger check earlier instead of just asking that `self.capture.isOpened()`, though it's not clear we would have a means of correcting it here.