### PR TITLE
Fixing RTSP Grabber Exception Handling

### DIFF
--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -642,7 +642,7 @@ class RTSPFrameGrabber(FrameGrabber):
             raise ValueError(
                 f"No RTSP URL provided for {camera_name}. Please add an rtsp_url attribute to the configuration."
             )
-        
+
         self.config = RTSPFrameGrabber._substitute_rtsp_password(config)
 
         rtsp_url = self.config["id"]["rtsp_url"]
@@ -693,7 +693,7 @@ class RTSPFrameGrabber(FrameGrabber):
         matches = re.findall(pattern, rtsp_url)
 
         if len(matches) == 0:
-            return config # make no change to config if no password placeholder is found
+            return config  # make no change to config if no password placeholder is found
         elif len(matches) > 1:
             raise ValueError("RTSP URL should contain no more than one placeholder for the password.")
 

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -3,7 +3,8 @@ Intended to check basic functionality like cropping, zooming, config validation,
 """
 
 import unittest
-from framegrab.grabber import FrameGrabber
+from framegrab.grabber import FrameGrabber, RTSPFrameGrabber
+import os
 
 class TestFrameGrabWithMockCamera(unittest.TestCase):
     def test_crop_pixels(self):
@@ -174,3 +175,41 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         # Should raise an exception because camera1 is duplicated
         with self.assertRaises(ValueError):
             FrameGrabber.create_grabbers(configs)
+
+    def test_substitute_rtsp_url(self):
+        """Test that the RTSP password is substituted correctly.
+        """
+        os.environ['RTSP_PASSWORD_1'] = 'password1'
+
+        config = {
+            'input_type': 'rtsp',
+            'id': {'rtsp_url': "rtsp://admin:{{RTSP_PASSWORD_1}}@10.0.0.1"},
+        }
+
+        substituted_config = RTSPFrameGrabber._substitute_rtsp_password(config)
+        substituted_rtsp_url = substituted_config['id']['rtsp_url']
+
+        assert substituted_rtsp_url == "rtsp://admin:password1@10.0.0.1"
+
+    def test_substitute_rtsp_url_password_not_set(self):
+        """Test that an exception is raised if the user adds a placeholder but neglects to set the environment variable.
+        """
+        config = {
+            'input_type': 'rtsp',
+            'id': {'rtsp_url': "rtsp://admin:{{SOME_NONEXISTENT_ENV_VARIABLE}}@10.0.0.1"},
+        }
+        
+        with self.assertRaises(ValueError):
+            RTSPFrameGrabber._substitute_rtsp_password(config)
+
+    def test_substitute_rtsp_url_without_placeholder(self):
+        """Users should be able to use RTSP urls without a password placeholder. In this case, the config should be returned unchanged.
+        """
+        config = {
+            'input_type': 'rtsp',
+            'id': {'rtsp_url': "rtsp://admin:password@10.0.0.1"},
+        }
+        
+        new_config = RTSPFrameGrabber._substitute_rtsp_password(config)
+
+        assert  new_config == config


### PR DESCRIPTION
Previously, when a user did not provide an RTSP URL for an RTSP grabber, it raised this exception: 
```
raise ValueError("RTSP URL should contain exactly one placeholder for the password.")
```
It would be more helpful to raise an exception that says "please provide an RTSP URL"

I adjusted the order of the guard clauses to allow this to happen.

I also made it possible for users to _not_ use password substitution. We should discuss if this is okay, but I believe some users might want to just have passwords in their yaml, which as far as I know, is okay.

I changed `_substitute_rtsp_password` to be a static method because it didn't actually use self, and I wanted to write a test for it without having to create an instance of the class.

I added a few tests for the changes I made. 