### PR TITLE
Fixing RTSP Grabber Exception Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ from framegrab import FrameGrabber, MotionDetector
 motion_threshold = 1.0
 
 config = {
-    'input_type': 'webcam',
+    'input_type': 'generic_usb',
 }
 grabber = FrameGrabber.create_grabber(config)
 m = MotionDetector(pct_threshold=motion_threshold)
@@ -243,6 +243,6 @@ We welcome contributions to FrameGrab! If you would like to contribute, please f
 
 ## License
 
-FrameGrab is released under the MIT License. For more information, please refer to the [LICENSE.txt](LICENSE.txt) file.
+FrameGrab is released under the MIT License. For more information, please refer to the [LICENSE.txt](https://github.com/groundlight/framegrab/blob/main/LICENSE.txt)
 
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,6 @@ We welcome contributions to FrameGrab! If you would like to contribute, please f
 
 ## License
 
-FrameGrab is released under the MIT License. For more information, please refer to the [LICENSE.txt](https://github.com/groundlight/framegrab/blob/main/LICENSE.txt)
+FrameGrab is released under the MIT License. For more information, please refer to the [LICENSE.txt](https://github.com/groundlight/framegrab/blob/main/LICENSE.txt) file.
 
 


### PR DESCRIPTION
Previously, when a user did not provide an RTSP URL for an RTSP grabber, it raised this exception: 
```
raise ValueError("RTSP URL should contain exactly one placeholder for the password.")
```
It would be more helpful to raise an exception that says "please provide an RTSP URL"

I adjusted the order of the guard clauses to allow this to happen.

I also made it possible for users to _not_ use password substitution. I believe some users might want to just have passwords in their yaml, which as far as I know, is okay.

I changed `_substitute_rtsp_password` to be a static method because it didn't actually use self, and I wanted to write a test for it without having to create an instance of the class.

I added a few tests for the changes I made. 