### PR TITLE
Fix for IR cameras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.5.1"
+version = "0.5.2"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.5.2"
+version = "0.6.0"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.6.0"
+version = "0.5.2"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -513,6 +513,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
         # Assign camera based on serial number if 1) serial_number was provided and 2) we know the
         # serial numbers of plugged in devices
         if found_cams:
+            logger.info(f'Checking for USB cameras with {len(found_cams)} cameras found.')
             for found_cam in found_cams:
                 if serial_number and serial_number != found_cam["serial_number"]:
                     continue
@@ -532,6 +533,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
                 )
         # If we don't know the serial numbers of the cameras, just assign the next available camera by index
         else:
+            logger.info("No USB cameras found with Linux commands. Assigning camera by index.")
             for idx in range(20):  # an arbitrarily high number to make sure we check for enough cams
                 if idx in GenericUSBFrameGrabber.indices_in_use:
                     continue  # Camera is already in use, moving on
@@ -581,6 +583,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
             return None
 
         has_ir_camera = self._has_ir_camera(camera_details["camera_name"])
+        logger.info(f'Camera "{camera_details["camera_name"]}" has IR camera: {has_ir_camera}')
         if has_ir_camera:
             ret, frame = capture.read()
             if not ret:

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -560,22 +560,22 @@ class GenericUSBFrameGrabber(FrameGrabber):
         GenericUSBFrameGrabber.indices_in_use.add(idx)
 
     def _validate_image_capture(self, capture: cv2.VideoCapture) -> bool:
-       """Check if the camera is able to grab a frame and that frame is a color frame.
-       We are excluding grayscale cameras in order to avoid connecting to IR cameras on webcams such
-       as the Logitech Brio
-       """
-       ret, frame = capture.read()
-       if not ret:
-           logger.error(f"Could not read frame from {capture}")
-           return False
-      
-       if self._is_grayscale(frame):
-           logger.warning(f"This camera's image is not a color image. Skipping this camera.")
-           capture.release()
-           return False
-    
-       return True
-    
+        """Check if the camera is able to grab a frame and that frame is a color frame.
+        We are excluding grayscale cameras in order to avoid connecting to IR cameras on webcams such
+        as the Logitech Brio
+        """
+        ret, frame = capture.read()
+        if not ret:
+            logger.error(f"Could not read frame from {capture}")
+            return False
+
+        if self._is_grayscale(frame):
+            logger.warning(f"This camera's image is not a color image. Skipping this camera.")
+            capture.release()
+            return False
+
+        return True
+
     def _is_grayscale(self, frame: np.ndarray) -> bool:
         """Check if the provided frame is grayscale."""
         b, g, r = cv2.split(frame)

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -32,6 +32,7 @@ OPERATING_SYSTEM = platform.system()
 DIGITAL_ZOOM_MAX = 4
 NOISE = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)  # in case a camera can't get a frame
 
+
 class InputTypes:
     """Defines the available input types from FrameGrabber objects"""
 
@@ -574,31 +575,31 @@ class GenericUSBFrameGrabber(FrameGrabber):
     #         return False
 
     #     return True
-    
+
     def _has_ir_camera(self, camera_name: str) -> bool:
-        """Check if the device contains an IR camera. 
-        
-        Cameras such as the Logitech Brio contain an infrared camera for unlocking the computer with features 
+        """Check if the device contains an IR camera.
+
+        Cameras such as the Logitech Brio contain an infrared camera for unlocking the computer with features
         such as Windows Hello. These cameras are not suitable for use in the context of this application, so we will
         exclude them.
         """
-        cameras_with_ir = ['logitech brio'] # we can add to this list as we discover more cameras with IR
+        cameras_with_ir = ["logitech brio"]  # we can add to this list as we discover more cameras with IR
         for i in cameras_with_ir:
             if i in camera_name.lower():
                 return True
         return False
-    
-    def _connect_to_video_capture(self, camera_details: Dict[str, str]) -> Union[cv2.VideoCapture , None]:
-        """Connect to the camera, check that it is open and not an IR camera. 
+
+    def _connect_to_video_capture(self, camera_details: Dict[str, str]) -> Union[cv2.VideoCapture, None]:
+        """Connect to the camera, check that it is open and not an IR camera.
 
         Return the camera if it is valid, otherwise return None.
         """
-        capture = cv2.VideoCapture(camera_details['idx'])
+        capture = cv2.VideoCapture(camera_details["idx"])
         if not capture.isOpened():
             logger.warning(f"Could not open camera with index {camera_details['idx']}")
             return None
-        
-        has_ir_camera = self._has_ir_camera(camera_details['camera_name'])
+
+        has_ir_camera = self._has_ir_camera(camera_details["camera_name"])
         if has_ir_camera:
             ret, frame = capture.read()
             if not ret:
@@ -640,8 +641,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
 
     @staticmethod
     def _run_system_command(command: str) -> str:
-        """Runs a Linux system command and returns the stdout as a string.
-        """
+        """Runs a Linux system command and returns the stdout as a string."""
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, _ = process.communicate()
         return stdout.decode("utf-8").strip()
@@ -658,7 +658,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
 
         # ls /dev/video* returns device paths for all detected cameras
         command = "ls /dev/video*"
-        output =  GenericUSBFrameGrabber._run_system_command(command)
+        output = GenericUSBFrameGrabber._run_system_command(command)
 
         if len(output) == 0:  # len is zero when no cameras are plugged in
             device_paths = []

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -664,7 +664,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
             serial_number = GenericUSBFrameGrabber._run_system_command(command)
 
             # find the camera name (e.g. Logitech Brio)
-            command = f"ls /sys/class/video4linux/{devname}/name"
+            command = f"cat /sys/class/video4linux/{devname}/name"
             camera_name = GenericUSBFrameGrabber._run_system_command(command)
 
             # find the index

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -567,12 +567,19 @@ class GenericUSBFrameGrabber(FrameGrabber):
            logger.error(f"Could not read frame from {capture}")
            return False
       
-       if len(frame.shape) != 3:
+       if self._is_grayscale(frame):
            logger.error(f"Frame from {capture} is not a color frame. Shape: {frame.shape}")
            return False
        
        logger.info(f'Found image resolution of {frame.shape}')
        return True
+    
+    def _is_grayscale(frame: np.ndarray) -> bool:
+        # Split the image into its color channels
+        b, g, r = cv2.split(frame)
+        
+        # Check if all channels are equal
+        return np.array_equal(b, g) and np.array_equal(g, r)
 
     def _grab_implementation(self) -> np.ndarray:
         # OpenCV VideoCapture buffers frames by default. It's usually not possible to turn buffering off.

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -529,7 +529,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
             else:
                 raise ValueError(
                     f"Unable to find USB camera with the specified serial_number: {serial_number}. "
-                    "Please ensure that the serial number is correct and that the camera is plugged in."
+                    "Please ensure that the serial number is correct, that the camera is plugged in, and that the camera is not already in use."
                 )
         # If we don't know the serial numbers of the cameras, just assign the next available camera by index
         else:

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -574,7 +574,7 @@ class GenericUSBFrameGrabber(FrameGrabber):
        logger.info(f'Found image resolution of {frame.shape}')
        return True
     
-    def _is_grayscale(frame: np.ndarray) -> bool:
+    def _is_grayscale(self, frame: np.ndarray) -> bool:
         # Split the image into its color channels
         b, g, r = cv2.split(frame)
         

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -605,6 +605,9 @@ class GenericUSBFrameGrabber(FrameGrabber):
         return np.array_equal(b, g) and np.array_equal(g, r)
 
     def _grab_implementation(self) -> np.ndarray:
+        if not self.capture.isOpened():
+            self.capture.open(self.idx)
+            
         # OpenCV VideoCapture buffers frames by default. It's usually not possible to turn buffering off.
         # Buffer can be set as low as 1, but even still, if we simply read once, we will get the buffered (stale) frame.
         # Assuming buffer size of 1, we need to read twice to get the current frame.

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -570,7 +570,8 @@ class GenericUSBFrameGrabber(FrameGrabber):
        if len(frame.shape) != 3:
            logger.error(f"Frame from {capture} is not a color frame. Shape: {frame.shape}")
            return False
-      
+       
+       logger.info(f'Found image resolution of {frame.shape}')
        return True
 
     def _grab_implementation(self) -> np.ndarray:

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -561,6 +561,8 @@ class GenericUSBFrameGrabber(FrameGrabber):
 
     def _validate_image_capture(self, capture: cv2.VideoCapture) -> bool:
        """Check if the camera is able to grab a frame and that frame is a color frame.
+       We are excluding grayscale cameras in order to avoid connecting to IR cameras on webcams such
+       as the Logitech Brio
        """
        ret, frame = capture.read()
        if not ret:
@@ -575,10 +577,10 @@ class GenericUSBFrameGrabber(FrameGrabber):
        return True
     
     def _is_grayscale(self, frame: np.ndarray) -> bool:
-        # Split the image into its color channels
+        """Check if the provided frame is grayscale.
+        """
         b, g, r = cv2.split(frame)
         
-        # Check if all channels are equal
         return np.array_equal(b, g) and np.array_equal(g, r)
 
     def _grab_implementation(self) -> np.ndarray:

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -570,10 +570,10 @@ class GenericUSBFrameGrabber(FrameGrabber):
            return False
       
        if self._is_grayscale(frame):
-           logger.error(f"Frame from {capture} is not a color frame. Shape: {frame.shape}")
+           logger.warning(f"This camera's image is not a color image. Skipping this camera.")
+           capture.release()
            return False
-       
-       logger.info(f'Found image resolution of {frame.shape}')
+    
        return True
     
     def _is_grayscale(self, frame: np.ndarray) -> bool:


### PR DESCRIPTION
Orin Nanos are able to see IR cameras on webcams such as the Logitech Brio. Because of this, they will actually grab the IR camera instead of the color camera, which produces not-so-useful images. Interestingly, Xaviers do not see the IR camera, so it's not an issue there. Sunil also reported this issue on a Raspberry Pi in https://github.com/groundlight/framegrab/issues/26. 

On Orin Nano:
```sh
$ ls /dev/video*
/dev/video0  /dev/video1  /dev/video2  /dev/video3
```

On Xavier:
```sh
$ ls /dev/video*
/dev/video1  /dev/video2
```

To fix this, we will skip an devices that have a name of "Logitech Brio" and produce grayscale frames. This is kind of a special case fix, but it seems like the best thing to do for now. If we discover any other cameras with this same behavior, we can update the list of devices that are known to have IR cameras. 

Once this PR is merged in and released to pypi, we can update the RPC server here: https://github.com/positronix-ai/rpc-server/pull/17

