### PR TITLE
Added support for RTSP discovery in autodiscover and CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.5.3"
+version = "0.5.4"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/cli/autodiscover.py
+++ b/src/framegrab/cli/autodiscover.py
@@ -5,8 +5,12 @@ import yaml
 from imgcat import imgcat
 
 from framegrab import FrameGrabber
+from framegrab.cli.clitools import (
+    PREVIEW_COMMAND_CHOICES,
+    PREVIEW_RTSP_COMMAND_CHOICES,
+    preview_image,
+)
 from framegrab.rtsp_discovery import AutodiscoverModes
-from framegrab.cli.clitools import PREVIEW_COMMAND_CHOICES, PREVIEW_RTSP_COMMAND_CHOICES, preview_image
 
 
 @click.command()

--- a/src/framegrab/cli/autodiscover.py
+++ b/src/framegrab/cli/autodiscover.py
@@ -26,7 +26,7 @@ from framegrab.rtsp_discovery import AutodiscoverModes
     default="light",
     show_default=True,
 )
-def autodiscover(preview: str, rtsp_discover_modes: str):
+def autodiscover(preview: str, rtsp_discover_modes: str = "light"):
     """Automatically discover cameras connected to the current host (e.g. USB)."""
     # Print message to stderr
     click.echo("Discovering cameras...", err=True)

--- a/src/framegrab/cli/autodiscover.py
+++ b/src/framegrab/cli/autodiscover.py
@@ -5,21 +5,29 @@ import yaml
 from imgcat import imgcat
 
 from framegrab import FrameGrabber
-from framegrab.cli.clitools import PREVIEW_COMMAND_CHOICES, preview_image
+from framegrab.rtsp_discovery import AutodiscoverModes
+from framegrab.cli.clitools import PREVIEW_COMMAND_CHOICES, PREVIEW_RTSP_COMMAND_CHOICES, preview_image
 
 
 @click.command()
-@click.argument(
-    "preview",
+@click.option(
+    "--preview",
     type=click.Choice(PREVIEW_COMMAND_CHOICES, case_sensitive=False),
     default="imgcat",
+    show_default=True,
 )
-def autodiscover(preview: str):
+@click.option(
+    "--rtsp_discover_modes",
+    type=click.Choice(PREVIEW_RTSP_COMMAND_CHOICES, case_sensitive=False),
+    default="light",
+    show_default=True,
+)
+def autodiscover(preview: str, rtsp_discover_modes: str):
     """Automatically discover cameras connected to the current host (e.g. USB)."""
     # Print message to stderr
     click.echo("Discovering cameras...", err=True)
 
-    grabbers = FrameGrabber.autodiscover()
+    grabbers = FrameGrabber.autodiscover(rtsp_discover_modes=rtsp_discover_modes)
 
     yaml_config = {
         "image_sources": [],

--- a/src/framegrab/cli/clitools.py
+++ b/src/framegrab/cli/clitools.py
@@ -5,6 +5,8 @@ import cv2
 from imgcat import imgcat
 from PIL import Image
 
+from framegrab.rtsp_discovery import AutodiscoverModes
+
 
 def imgcat_preview(name: str, frame):
     """Displays the given frame in the terminal using imgcat.
@@ -44,6 +46,7 @@ _PREVIEW_COMMANDS = {
 }
 
 PREVIEW_COMMAND_CHOICES = list(_PREVIEW_COMMANDS.keys())
+PREVIEW_RTSP_COMMAND_CHOICES = [mode.value for mode in AutodiscoverModes]
 
 
 def preview_image(frame, title: str, output_type: str):

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -13,7 +13,7 @@ import cv2
 import numpy as np
 import yaml
 
-from .rtsp_discovery import AutodiscoverModes, discover_camera_ips
+from .rtsp_discovery import AutodiscoverModes, RTSPDiscovery
 from .unavailable_module import UnavailableModule
 
 logger = logging.getLogger(__name__)
@@ -302,7 +302,7 @@ class FrameGrabber(ABC):
             logger.info(f"Autodiscovering {input_type} cameras...")
             
             if input_type == InputTypes.RTSP:
-                onvif_devices = discover_camera_ips(try_default_logins=rtsp_discover_modes)
+                onvif_devices = RTSPDiscovery.discover_onvif_devices(auto_discover_modes=rtsp_discover_modes)
                 for device in onvif_devices:
                     for index, rtsp_url in enumerate(device.rtsp_urls):
                         grabber = FrameGrabber.create_grabber(

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -272,15 +272,17 @@ class FrameGrabber(ABC):
         return grabber
 
     @staticmethod
-    def autodiscover(warmup_delay: float = 1.0, rtsp_discover_modes: AutodiscoverModes = AutodiscoverModes.light) -> dict:
+    def autodiscover(
+        warmup_delay: float = 1.0, rtsp_discover_modes: AutodiscoverModes = AutodiscoverModes.light
+    ) -> dict:
         """Autodiscovers cameras and returns a dictionary of FrameGrabber objects
 
         warmup_delay (float, optional): The number of seconds to wait after creating the grabbers. USB
             cameras often need a moment to warm up before they can be used; grabbing frames too early
             might result in dark or blurry images.
             Defaults to 1.0. Only happens if there are any generic_usb cameras in the config list.
-        
-        rtsp_discover_modes (AutodiscoverModes, optional): Options to try different default credentials 
+
+        rtsp_discover_modes (AutodiscoverModes, optional): Options to try different default credentials
             stored in DEFAULT_CREDENTIALS for RTSP cameras.
             Consists of four options:
                 disable: Disable guessing camera credentials.
@@ -300,7 +302,7 @@ class FrameGrabber(ABC):
         grabber_list = []
         for input_type in autodiscoverable_input_types:
             logger.info(f"Autodiscovering {input_type} cameras...")
-            
+
             if input_type == InputTypes.RTSP:
                 onvif_devices = RTSPDiscovery.discover_onvif_devices(auto_discover_modes=rtsp_discover_modes)
                 for device in onvif_devices:
@@ -316,7 +318,7 @@ class FrameGrabber(ABC):
                         )
                         grabber_list.append(grabber)
                 continue
-            
+
             for _ in range(
                 100
             ):  # an arbitrarily high value so that we look for enough cameras, but this never becomes an infinite loop

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -13,6 +13,7 @@ import cv2
 import numpy as np
 import yaml
 
+from .rtsp_discovery import AutodiscoverModes, discover_camera_ips
 from .unavailable_module import UnavailableModule
 
 logger = logging.getLogger(__name__)
@@ -271,24 +272,51 @@ class FrameGrabber(ABC):
         return grabber
 
     @staticmethod
-    def autodiscover(warmup_delay: float = 1.0) -> dict:
+    def autodiscover(warmup_delay: float = 1.0, rtsp_discover_modes: AutodiscoverModes = AutodiscoverModes.light) -> dict:
         """Autodiscovers cameras and returns a dictionary of FrameGrabber objects
 
         warmup_delay (float, optional): The number of seconds to wait after creating the grabbers. USB
             cameras often need a moment to warm up before they can be used; grabbing frames too early
             might result in dark or blurry images.
             Defaults to 1.0. Only happens if there are any generic_usb cameras in the config list.
+        
+        rtsp_discover_modes (AutodiscoverModes, optional): Options to try different default credentials 
+            stored in DEFAULT_CREDENTIALS for RTSP cameras.
+            Consists of four options:
+                disable: Disable guessing camera credentials.
+                light: Only try first two usernames and passwords ("admin:admin" and no username/password).
+                complete_fast: Try the entire DEFAULT_CREDENTIALS without delays in between.
+                complete_slow: Try the entire DEFAULT_CREDENTIALS with a delay of 1 seconds in between.
+            Defaults to AutodiscoverModes.light.
         """
         autodiscoverable_input_types = (
             InputTypes.REALSENSE,
             InputTypes.GENERIC_USB,
             InputTypes.BASLER,
+            InputTypes.RTSP,
         )
 
         # Autodiscover the grabbers
         grabber_list = []
         for input_type in autodiscoverable_input_types:
             logger.info(f"Autodiscovering {input_type} cameras...")
+            
+            if input_type == InputTypes.RTSP:
+                onvif_devices = discover_camera_ips(try_default_logins=rtsp_discover_modes)
+                for device in onvif_devices:
+                    for index, rtsp_url in enumerate(device.rtsp_urls):
+                        grabber = FrameGrabber.create_grabber(
+                            {
+                                "input_type": input_type,
+                                "id": {"rtsp_url": rtsp_url},
+                                "name": f"RTSP Camera - {device.ip} - {index}",
+                            },
+                            autogenerate_name=False,
+                            warmup_delay=0,
+                        )
+                        grabber_list.append(grabber)
+                continue
+            
             for _ in range(
                 100
             ):  # an arbitrarily high value so that we look for enough cameras, but this never becomes an infinite loop


### PR DESCRIPTION
This PR added support for RTSP discovery in the built-in `FrameGrabber.autodiscover()` function and also can be called in CLI.