### PR TITLE
Add exception when grabbing fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.5.3"
+version = "0.5.4"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/__init__.py
+++ b/src/framegrab/__init__.py
@@ -1,6 +1,7 @@
 from .cli.clitools import preview_image
 from .grabber import FrameGrabber
 from .motion import MotionDetector
+from .exceptions import GrabError
 from .rtsp_discovery import AutodiscoverModes, ONVIFDeviceInfo, RTSPDiscovery
 
 try:

--- a/src/framegrab/exceptions.py
+++ b/src/framegrab/exceptions.py
@@ -1,0 +1,6 @@
+class GrabError(Exception):
+    """Exception raised for errors in the frame grabbing process.
+    """
+    def __init__(self, message="Failed to grab frame from camera."):
+        self.message = message
+        super().__init__(self.message)

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -14,6 +14,7 @@ import numpy as np
 import yaml
 
 from .unavailable_module import UnavailableModule
+from .exceptions import GrabError
 
 logger = logging.getLogger(__name__)
 
@@ -325,6 +326,11 @@ class FrameGrabber(ABC):
         Returns a frame.
         """
         frame = self._grab_implementation()
+
+        if frame is None:
+            name = self.config['name'] # all grabbers should have a name, either user-provided or generated
+            error_msg = f'Failed to grab frame from {name}'
+            raise GrabError(error_msg)
 
         # apply post processing operations
         frame = self._crop(frame)


### PR DESCRIPTION
Currently if a framegrabber fails to capture a frame (if the camera becomes disconnected or is otherwise misbehaving), an unfriendly exception is raised (some downstream operations try to crop and scale a None frame), resulting in this error: 
![image](https://github.com/user-attachments/assets/2c76c9b8-8efb-433a-a2ba-3692c1708305)

This PR adds a custom exception `framegrab.exceptions.GrabError` and raises it in this situation.
