### PR TITLE
Added Workaround for WSDiscovery Bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.6.0"
+version = "0.6.1"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/rtsp_discovery.py
+++ b/src/framegrab/rtsp_discovery.py
@@ -67,7 +67,13 @@ class ONVIFDeviceInfo(BaseModel):
 class RTSPDiscovery:
     """Simple RTSP camera discovery with ONVIF capabilities"""
     
-    wsd = WSDiscovery()
+    _wsd_instance = None
+    
+    @classmethod
+    def get_wsd(cls):
+        if cls._wsd_instance is None:
+            cls._wsd_instance = WSDiscovery()
+        return cls._wsd_instance
 
     @staticmethod
     def discover_onvif_devices(
@@ -98,7 +104,7 @@ class RTSPDiscovery:
             return device_ips
         
         try:
-            wsd = RTSPDiscovery.wsd
+            wsd = RTSPDiscovery.get_wsd()
             wsd.start()
             types = [QName("http://www.onvif.org/ver10/network/wsdl", "NetworkVideoTransmitter")]
             ret = wsd.searchServices(types=types)

--- a/src/framegrab/rtsp_discovery.py
+++ b/src/framegrab/rtsp_discovery.py
@@ -66,6 +66,8 @@ class ONVIFDeviceInfo(BaseModel):
 
 class RTSPDiscovery:
     """Simple RTSP camera discovery with ONVIF capabilities"""
+    
+    wsd = WSDiscovery()
 
     @staticmethod
     def discover_onvif_devices(
@@ -94,10 +96,9 @@ class RTSPDiscovery:
         if auto_discover_mode == AutodiscoverMode.off:
             logger.debug("ONVIF device discovery disabled")
             return device_ips
-
-        wsd = WSDiscovery()
         
         try:
+            wsd = RTSPDiscovery.wsd
             wsd.start()
             types = [QName("http://www.onvif.org/ver10/network/wsdl", "NetworkVideoTransmitter")]
             ret = wsd.searchServices(types=types)

--- a/src/framegrab/rtsp_discovery.py
+++ b/src/framegrab/rtsp_discovery.py
@@ -70,7 +70,14 @@ class RTSPDiscovery:
     _wsd_instance = None
     
     @classmethod
-    def get_wsd(cls):
+    def _get_wsd(cls):
+        """
+        Get the WSDiscovery instance, creating it if it doesn't exist.
+        
+        Returns:
+        WSDiscovery: The WSDiscovery instance.
+        """
+        
         if cls._wsd_instance is None:
             cls._wsd_instance = WSDiscovery()
         return cls._wsd_instance
@@ -104,7 +111,7 @@ class RTSPDiscovery:
             return device_ips
         
         try:
-            wsd = RTSPDiscovery.get_wsd()
+            wsd = RTSPDiscovery._get_wsd()
             wsd.start()
             types = [QName("http://www.onvif.org/ver10/network/wsdl", "NetworkVideoTransmitter")]
             ret = wsd.searchServices(types=types)

--- a/src/framegrab/rtsp_discovery.py
+++ b/src/framegrab/rtsp_discovery.py
@@ -96,23 +96,27 @@ class RTSPDiscovery:
             return device_ips
 
         wsd = WSDiscovery()
-        wsd.start()
-        types = [QName("http://www.onvif.org/ver10/network/wsdl", "NetworkVideoTransmitter")]
-        ret = wsd.searchServices(types=types)
-        for service in ret:
-            xaddr = service.getXAddrs()[0]
-            parsed_url = urllib.parse.urlparse(xaddr)
-            ip = parsed_url.hostname
-            port = parsed_url.port or 80  # Use the default port 80 if not specified
+        
+        try:
+            wsd.start()
+            types = [QName("http://www.onvif.org/ver10/network/wsdl", "NetworkVideoTransmitter")]
+            ret = wsd.searchServices(types=types)
+            for service in ret:
+                xaddr = service.getXAddrs()[0]
+                parsed_url = urllib.parse.urlparse(xaddr)
+                ip = parsed_url.hostname
+                port = parsed_url.port or 80  # Use the default port 80 if not specified
 
-            logger.debug(f"Found ONVIF service at {xaddr}")
-            device_ip = ONVIFDeviceInfo(ip=ip, port=port, username="", password="", xaddr=xaddr, rtsp_urls=[])
+                logger.debug(f"Found ONVIF service at {xaddr}")
+                device_ip = ONVIFDeviceInfo(ip=ip, port=port, username="", password="", xaddr=xaddr, rtsp_urls=[])
 
-            if auto_discover_mode is not AutodiscoverMode.ip_only:
-                RTSPDiscovery._try_logins(device=device_ip, auto_discover_mode=auto_discover_mode)
+                if auto_discover_mode is not AutodiscoverMode.ip_only:
+                    RTSPDiscovery._try_logins(device=device_ip, auto_discover_mode=auto_discover_mode)
 
-            device_ips.append(device_ip)
-        wsd.stop()
+                device_ips.append(device_ip)
+        finally:
+            wsd.stop()
+            
         return device_ips
 
     @staticmethod

--- a/src/framegrab/rtsp_discovery.py
+++ b/src/framegrab/rtsp_discovery.py
@@ -66,18 +66,18 @@ class ONVIFDeviceInfo(BaseModel):
 
 class RTSPDiscovery:
     """Simple RTSP camera discovery with ONVIF capabilities"""
-    
+
     _wsd_instance = None
-    
+
     @classmethod
     def _get_wsd(cls):
         """
         Get the WSDiscovery instance, creating it if it doesn't exist.
-        
+
         Returns:
         WSDiscovery: The WSDiscovery instance.
         """
-        
+
         if cls._wsd_instance is None:
             cls._wsd_instance = WSDiscovery()
         return cls._wsd_instance
@@ -109,7 +109,7 @@ class RTSPDiscovery:
         if auto_discover_mode == AutodiscoverMode.off:
             logger.debug("ONVIF device discovery disabled")
             return device_ips
-        
+
         try:
             wsd = RTSPDiscovery._get_wsd()
             wsd.start()
@@ -130,7 +130,7 @@ class RTSPDiscovery:
                 device_ips.append(device_ip)
         finally:
             wsd.stop()
-            
+
         return device_ips
 
     @staticmethod

--- a/src/framegrab/rtsp_discovery.py
+++ b/src/framegrab/rtsp_discovery.py
@@ -129,7 +129,7 @@ class RTSPDiscovery:
 
                 device_ips.append(device_ip)
         finally:
-            wsd.stop()
+            wsd.stop()  # This is supposed to clean up the threads but it doesn't seem to work, sock is still open after running this
 
         return device_ips
 


### PR DESCRIPTION
This PR tries to solve an issue for WSDiscovery that is still binding the socket after it has been instantiated. This PR provides a workaround by creating a singleton object for WSDiscovery so that it does not instantiate more than once.