### PR TITLE
Fix YAML example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,12 @@ Frame Grabbers are defined by a configuration dict which is usually stored as YA
 Here's an example of a single USB camera configured with several options:
 ```python
 config = """
-name: Front Door Camera
-input_type: generic_usb
-id:
-  serial_number: 23432570
+name: Raspberry Pi Ribbon Cable Camera
+input_type: rpi_csi2
 options:
     resolution:
-        height: 1080
-        width: 1920
+        height: 720
+        width: 1280
     zoom:
         digital: 1.5
 """
@@ -101,15 +99,16 @@ If you have multiple cameras of the same type plugged in, it's recommended that 
 Below is a sample yaml file containing configurations for three different cameras.
 ```yaml
 image_sources: 
-  - name: on robot arm
-    input_type: realsense
+  - name: On Robot Arm
+    input_type: basler
+    id:
+      serial_number: A24P1V4T
     options:
-      depth:
-        side_by_side: 1
       crop:
         relative:
+          top: 0.3
           right: 0.8
-  - name: conference room
+  - name: Chip Bin
     input_type: rtsp
     id:
       rtsp_url: rtsp://admin:password@192.168.1.20/cam/realmonitor?channel=1&subtype=0
@@ -120,7 +119,7 @@ image_sources:
           bottom: 1100
           left: 1100
           right: 2000
-  - name: workshop
+  - name: Over CNC Machine
     input_type: generic_usb
     id:
       serial_number: B77D3A8F
@@ -157,7 +156,7 @@ The table below shows all available configurations and the cameras to which they
 | options.crop.relative.bottom | 0.9          | optional   | optional  | optional  | optional  | optional  |
 | options.crop.relative.left | 0.1            | optional   | optional  | optional  | optional  | optional  |
 | options.crop.relative.right | 0.9            | optional   | optional  | optional  | optional  | optional  |
-| options.depth.side_by_side | 1              | -          | -         | -         | optional  | optional  |
+| options.depth.side_by_side | 1              | -          | -         | -         | optional  | -  |
 | options.num_90_deg_rotations | 2              | optional          | optional         | optional         | optional  | optional  |
 | options.keep_connection_open | True              | -          | optional         | -         | -  | - |
 | options.max_fps | 30              | -          | optional         | -         | -  | - |

--- a/README.md
+++ b/README.md
@@ -99,26 +99,26 @@ If you have multiple cameras of the same type plugged in, it's recommended that 
 
 Below is a sample yaml file containing configurations for three different cameras.
 ```yaml
-GL_CAMERAS: |
+image_sources: 
   - name: on robot arm
     input_type: realsense
-    options: 
+    options:
       depth:
         side_by_side: 1
       crop:
         relative:
-          right: .8
+          right: 0.8
   - name: conference room
-      input_type: rtsp
-      id: 
-        rtsp_url: rtsp://admin:password@192.168.1.20/cam/realmonitor?channel=1&subtype=0
-      options:
-        crop:
-          pixels:
-            top: 350
-            bottom: 1100
-            left: 1100
-            right: 2000
+    input_type: rtsp
+    id:
+      rtsp_url: rtsp://admin:password@192.168.1.20/cam/realmonitor?channel=1&subtype=0
+    options:
+      crop:
+        pixels:
+          top: 350
+          bottom: 1100
+          left: 1100
+          right: 2000
   - name: workshop
     input_type: generic_usb
     id:
@@ -127,16 +127,9 @@ GL_CAMERAS: |
 You can load the configurations from the yaml file and use the cameras in the following manner.
 ```python
 from framegrab import FrameGrabber
-import yaml
 
-# load the configurations from yaml
 config_path = 'camera_config.yaml'
-with open(config_path, 'r') as f:
-    data = yaml.safe_load(f)
-    configs = yaml.safe_load(data['GL_CAMERAS'])
-
-# create the grabbers
-grabbers = FrameGrabber.create_grabbers(configs)
+grabbers = FrameGrabber.from_yaml(config_path)
 
 for grabber in grabbers.values():
     print(grabber.config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.6.2"
+version = "0.6.3"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"


### PR DESCRIPTION
The example yaml usage in the readme had a couple problems:
1) Indentation error in the yaml
2) it used an outdated way of loading the yaml, not leveraging the newer `FrameGrabber.from_yaml` method.

This PR fixes both issues. 