### PR TITLE
Better logic for updating cv2.VideoCapture resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.6.3"
+version = "0.6.4"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -481,9 +481,9 @@ class FrameGrabber(ABC):
         resolution = self.config.get("options", {}).get("resolution")
         if resolution is None:
             return
-        else:
-            new_height = resolution.get("height")
-            new_width = resolution.get("width")
+
+        new_height = resolution.get("height")
+        new_width = resolution.get("width")
 
         if new_width:
             current_width = int(self.capture.get(cv2.CAP_PROP_FRAME_WIDTH))

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -474,14 +474,26 @@ class FrameGrabber(ABC):
         If the FrameGrabber lacks both of these properties (height and width), this method
         will do nothing.
         """
-        resolution = self.config.get("options", {}).get("resolution", {})
-        height = resolution.get("height")
-        width = resolution.get("width")
 
-        if width:
-            self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, width)
-        if height:
-            self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+        current_height = int(self.capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        current_width = int(self.capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+
+        logger.info(f'Found current resolution of {self.config["name"]} as {current_height} x {current_width}')
+
+        resolution = self.config.get("options", {}).get("resolution", {})
+        new_height = resolution.get("height")
+        new_width = resolution.get("width")
+
+        # Updating the resolution on a cv2.VideoCapture object is a non-trial operation, can take ~0.8 seconds
+        # so we should avoid doing this if the resolution isn't actually changing
+        if current_height == new_height and current_width == new_width:
+            logger.info('The new resolution is the same as the current resolution. Passing.')
+            return 
+
+        if new_width:
+            self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, new_width)
+        if new_height:
+            self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, new_height)
 
     def apply_options(self, options: dict) -> None:
         """Update generic options such as crop and zoom as well as


### PR DESCRIPTION
Currently, if a user creates a `FrameGrabber` object and supplies a config that contains a resolution, the resolution will be updated each time the `grab` method is called via `_set_cv2_resolution`. This is bad because it is a non-trivial operation and can significantly slow down grabbing.

This PR adds logic to check if the resolution in the config is new and only updates if it is new. 