### PR TITLE
Moving the rotate operation before cropping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.6.4"
+version = "0.7.0"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -374,9 +374,9 @@ class FrameGrabber(ABC):
             raise GrabError(error_msg)
 
         # apply post processing operations
+        frame = self._rotate(frame)
         frame = self._crop(frame)
         frame = self._digital_zoom(frame)
-        frame = self._rotate(frame)
         return frame
 
     def _autogenerate_name(self) -> None:


### PR DESCRIPTION
We've discussed previously that it would make more sense to rotate the image _before_ cropping. I am finding this to be very much the case as I am adding panning capabilities to the URCap. This PR simply changes that. 