### PR TITLE
Removing rpi_csi2 from autodiscoverable types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.6.4"
+version = "0.6.5"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -305,7 +305,6 @@ class FrameGrabber(ABC):
             InputTypes.GENERIC_USB,
             InputTypes.BASLER,
             InputTypes.RTSP,
-            InputTypes.RPI_CSI2,
         )
 
         # Autodiscover the grabbers


### PR DESCRIPTION
Removing rpi_csi2 from autodiscoverable types because it is not supported yet