### PR TITLE
Undoing wsdiscovery's logging configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.7.0"
+version = "0.7.1"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.10.0"
+version = "0.10.1"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -23,6 +23,8 @@ from .unavailable_module import UnavailableModule
 root_logger = logging.getLogger()
 if root_logger.hasHandlers():
     root_logger.handlers.clear()
+    
+logger = logging.getLogger(__name__)
 
 # Create a logger for this module
 # -- Optional imports --
@@ -50,7 +52,6 @@ try:
 except ImportError as e:
     streamlink = UnavailableModule(e)
 
-logger = logging.getLogger(__name__)
 
 OPERATING_SYSTEM = platform.system()
 DIGITAL_ZOOM_MAX = 4

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -17,6 +17,14 @@ from .exceptions import GrabError
 from .rtsp_discovery import AutodiscoverMode, RTSPDiscovery
 from .unavailable_module import UnavailableModule
 
+# The wsdiscovery packages calls logging.basicConfig, which will wipe out any logging config
+# that framegrab users have set, which is not good. To clear the config that wsdiscovery sets, we
+# will run the following
+root_logger = logging.getLogger()
+if root_logger.hasHandlers():
+    root_logger.handlers.clear()
+
+# Create a logger for this module
 logger = logging.getLogger(__name__)
 
 # Optional imports

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -23,7 +23,7 @@ from .unavailable_module import UnavailableModule
 root_logger = logging.getLogger()
 if root_logger.hasHandlers():
     root_logger.handlers.clear()
-    
+
 logger = logging.getLogger(__name__)
 
 # Create a logger for this module


### PR DESCRIPTION
`wsdiscovery`, a depedency of framegrab calls `logging.basicConfig`, which is not good. This will override an logging configurations that framegrab users attempt to set. This PR removes that config.

Here is some output from my machine that pointed me towards the fact that `wsdicovery` was calling `logging.basicConfig`
```
tim@tim:~/gl-demo$ grep -r "basicConfig" $(poetry env info --path)/lib/python*/site-packages/
/home/tim/gl-demo/.venv/lib/python3.11/site-packages/wsdiscovery/cmdline.py:logging.basicConfig()
/home/tim/gl-demo/.venv/lib/python3.11/site-packages/wsdiscovery/asynch.py:logging.basicConfig()
```