### PR TITLE
Handle case where one grabber config is invalid in `create_grabbers`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.9.2"
+version = "0.10.0"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.9.1"
+version = "0.9.2"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/__init__.py
+++ b/src/framegrab/__init__.py
@@ -18,7 +18,8 @@ except ModuleNotFoundError:
 __all__ = [
     "FrameGrabber",
     "MotionDetector",
-    "GrabError" "RTSPDiscovery",
+    "GrabError",
+    "RTSPDiscovery",
     "ONVIFDeviceInfo",
     "AutodiscoverMode",
     "preview_image",

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -131,8 +131,14 @@ class FrameGrabber(ABC):
         # Create the grabbers
         grabber_list = []
         for config in configs:
-            grabber = FrameGrabber.create_grabber(config, autogenerate_name=False, warmup_delay=0)
-            grabber_list.append(grabber)
+            try:
+                grabber = FrameGrabber.create_grabber(config, autogenerate_name=False, warmup_delay=0)
+                grabber_list.append(grabber)
+            except ValueError as e:
+                logger.warning(
+                    f"Failed to connect to camera '{config["name"]}'. Please check its connection and provided configuration: {config}", 
+                    exc_info=True
+                    )
 
         grabbers = FrameGrabber.grabbers_to_dict(grabber_list)
 

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -136,7 +136,7 @@ class FrameGrabber(ABC):
                 grabber_list.append(grabber)
             except ValueError as e:
                 camera_name = config.get("name", "Unnamed Camera")
-                logger.warning(
+                logger.error(
                     f"Failed to connect to {camera_name}. Please check its connection and provided configuration: {config}",
                     exc_info=True,
                 )

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -136,7 +136,7 @@ class FrameGrabber(ABC):
                 grabber_list.append(grabber)
             except ValueError as e:
                 logger.warning(
-                    f"Failed to connect to camera '{config["name"]}'. Please check its connection and provided configuration: {config}", 
+                    f"Failed to connect to camera {config['name']}. Please check its connection and provided configuration: {config}", 
                     exc_info=True
                     )
 

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -135,8 +135,9 @@ class FrameGrabber(ABC):
                 grabber = FrameGrabber.create_grabber(config, autogenerate_name=False, warmup_delay=0)
                 grabber_list.append(grabber)
             except ValueError as e:
+                camera_name = config.get("name", "Unnamed Camera")
                 logger.warning(
-                    f"Failed to connect to camera {config['name']}. Please check its connection and provided configuration: {config}",
+                    f"Failed to connect to {camera_name}. Please check its connection and provided configuration: {config}",
                     exc_info=True,
                 )
 

--- a/test/test_framegrab_with_filestream.py
+++ b/test/test_framegrab_with_filestream.py
@@ -1,138 +1,138 @@
-import os
-import shutil
-import tempfile
-import unittest
+# import os
+# import shutil
+# import tempfile
+# import unittest
 
-import cv2
-import numpy as np
+# import cv2
+# import numpy as np
 
-from framegrab.grabber import FileStreamFrameGrabber
+# from framegrab.grabber import FileStreamFrameGrabber
 
 
-class TestFileStreamFrameGrabber(unittest.TestCase):
-    def setUp(self):
-        """Create temporary video files for testing."""
+# class TestFileStreamFrameGrabber(unittest.TestCase):
+#     def setUp(self):
+#         """Create temporary video files for testing."""
 
-        self.temp_dir = tempfile.mkdtemp()
-        self.mp4_path = os.path.join(self.temp_dir, "test_video.mp4")
-        self.mjpeg_path = os.path.join(self.temp_dir, "test_video.mjpeg")
+#         self.temp_dir = tempfile.mkdtemp()
+#         self.mp4_path = os.path.join(self.temp_dir, "test_video.mp4")
+#         self.mjpeg_path = os.path.join(self.temp_dir, "test_video.mjpeg")
 
-        # Create test videos
-        width, height = 640, 480
-        fps = 30.0
+#         # Create test videos
+#         width, height = 640, 480
+#         fps = 30.0
 
-        # Create MP4 test video
-        fourcc_mp4 = cv2.VideoWriter.fourcc(*"mp4v")
-        writer_mp4 = cv2.VideoWriter(self.mp4_path, fourcc_mp4, fps, (width, height))
+#         # Create MP4 test video
+#         fourcc_mp4 = cv2.VideoWriter.fourcc(*"mp4v")
+#         writer_mp4 = cv2.VideoWriter(self.mp4_path, fourcc_mp4, fps, (width, height))
 
-        # Create MJPEG test video
-        fourcc_mjpeg = cv2.VideoWriter.fourcc(*"MJPG")
-        writer_mjpeg = cv2.VideoWriter(
-            self.mjpeg_path, fourcc_mjpeg, fps, (width, height)
-        )
+#         # Create MJPEG test video
+#         fourcc_mjpeg = cv2.VideoWriter.fourcc(*"MJPG")
+#         writer_mjpeg = cv2.VideoWriter(
+#             self.mjpeg_path, fourcc_mjpeg, fps, (width, height)
+#         )
 
-        # Generate 1 second of frames for both videos
-        for _ in range(int(fps)):
-            frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
-            writer_mp4.write(frame)
-            writer_mjpeg.write(frame)
+#         # Generate 1 second of frames for both videos
+#         for _ in range(int(fps)):
+#             frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+#             writer_mp4.write(frame)
+#             writer_mjpeg.write(frame)
 
-        writer_mp4.release()
-        writer_mjpeg.release()
+#         writer_mp4.release()
+#         writer_mjpeg.release()
 
-        self.base_config_mp4 = {
-            "input_type": "file",
-            "name": "test_video_mp4",
-            "id": {"filename": self.mp4_path},
-        }
+#         self.base_config_mp4 = {
+#             "input_type": "file",
+#             "name": "test_video_mp4",
+#             "id": {"filename": self.mp4_path},
+#         }
 
-        self.base_config_mjpeg = {
-            "input_type": "file",
-            "name": "test_video_mjpeg",
-            "id": {"filename": self.mjpeg_path},
-        }
+#         self.base_config_mjpeg = {
+#             "input_type": "file",
+#             "name": "test_video_mjpeg",
+#             "id": {"filename": self.mjpeg_path},
+#         }
 
-    def tearDown(self):
-        """Clean up temporary files."""
-        shutil.rmtree(self.temp_dir)
+#     def tearDown(self):
+#         """Clean up temporary files."""
+#         shutil.rmtree(self.temp_dir)
 
-    def test_init_success_mp4(self):
-        """Test successful initialization with MP4."""
-        grabber = FileStreamFrameGrabber(self.base_config_mp4)
-        self.assertEqual(grabber.fps_source, 30.0)
-        self.assertFalse(grabber.should_drop_frames)
-        grabber.release()
+#     def test_init_success_mp4(self):
+#         """Test successful initialization with MP4."""
+#         grabber = FileStreamFrameGrabber(self.base_config_mp4)
+#         self.assertEqual(grabber.fps_source, 30.0)
+#         self.assertFalse(grabber.should_drop_frames)
+#         grabber.release()
 
-    def test_init_success_mjpeg(self):
-        """Test successful initialization with MJPEG."""
-        with FileStreamFrameGrabber(self.base_config_mjpeg) as grabber:
-            # MJPEG files have variable frame rates and also the FPS that cv2 returns is not accurate
-            self.assertGreater(grabber.fps_source, 20.0)
-            self.assertLess(grabber.fps_source, 40.0)
-            self.assertFalse(grabber.should_drop_frames)
+#     def test_init_success_mjpeg(self):
+#         """Test successful initialization with MJPEG."""
+#         with FileStreamFrameGrabber(self.base_config_mjpeg) as grabber:
+#             # MJPEG files have variable frame rates and also the FPS that cv2 returns is not accurate
+#             self.assertGreater(grabber.fps_source, 20.0)
+#             self.assertLess(grabber.fps_source, 40.0)
+#             self.assertFalse(grabber.should_drop_frames)
 
-    def test_init_with_fps_target_mp4(self):
-        """Test initialization with FPS target for MP4."""
-        target_fps = 15.0
-        config = self.base_config_mp4.copy()
-        config["options"] = {"max_fps": target_fps}
+#     def test_init_with_fps_target_mp4(self):
+#         """Test initialization with FPS target for MP4."""
+#         target_fps = 15.0
+#         config = self.base_config_mp4.copy()
+#         config["options"] = {"max_fps": target_fps}
 
-        grabber = FileStreamFrameGrabber(config)
-        self.assertTrue(grabber.should_drop_frames)
-        self.assertEqual(grabber.fps_target, target_fps)
-        grabber.release()
+#         grabber = FileStreamFrameGrabber(config)
+#         self.assertTrue(grabber.should_drop_frames)
+#         self.assertEqual(grabber.fps_target, target_fps)
+#         grabber.release()
 
-    def test_init_with_fps_target_mjpeg(self):
-        """Test initialization with FPS target for MJPEG."""
-        target_fps = 15.0
-        config = self.base_config_mjpeg.copy()
-        config["options"] = {"max_fps": target_fps}
+#     def test_init_with_fps_target_mjpeg(self):
+#         """Test initialization with FPS target for MJPEG."""
+#         target_fps = 15.0
+#         config = self.base_config_mjpeg.copy()
+#         config["options"] = {"max_fps": target_fps}
 
-        grabber = FileStreamFrameGrabber(config)
-        self.assertTrue(grabber.should_drop_frames)
-        self.assertEqual(grabber.fps_target, target_fps)
-        grabber.release()
+#         grabber = FileStreamFrameGrabber(config)
+#         self.assertTrue(grabber.should_drop_frames)
+#         self.assertEqual(grabber.fps_target, target_fps)
+#         grabber.release()
 
-    def test_init_without_filename(self):
-        """Test initialization fails without filename."""
-        config = {"input_type": "file", "name": "test_video"}
+#     def test_init_without_filename(self):
+#         """Test initialization fails without filename."""
+#         config = {"input_type": "file", "name": "test_video"}
 
-        with self.assertRaises(ValueError):
-            FileStreamFrameGrabber(config)
+#         with self.assertRaises(ValueError):
+#             FileStreamFrameGrabber(config)
 
-    def test_grab_frame_mp4(self):
-        """Test frame grabbing from MP4."""
-        grabber = FileStreamFrameGrabber(self.base_config_mp4)
-        frame = grabber.grab()
+#     def test_grab_frame_mp4(self):
+#         """Test frame grabbing from MP4."""
+#         grabber = FileStreamFrameGrabber(self.base_config_mp4)
+#         frame = grabber.grab()
 
-        self.assertIsInstance(frame, np.ndarray)
-        self.assertEqual(frame.shape, (480, 640, 3))
-        grabber.release()
+#         self.assertIsInstance(frame, np.ndarray)
+#         self.assertEqual(frame.shape, (480, 640, 3))
+#         grabber.release()
 
-    def test_grab_frame_mjpeg(self):
-        """Test frame grabbing from MJPEG."""
-        grabber = FileStreamFrameGrabber(self.base_config_mjpeg)
-        frame = grabber.grab()
+#     def test_grab_frame_mjpeg(self):
+#         """Test frame grabbing from MJPEG."""
+#         grabber = FileStreamFrameGrabber(self.base_config_mjpeg)
+#         frame = grabber.grab()
 
-        self.assertIsInstance(frame, np.ndarray)
-        self.assertEqual(frame.shape, (480, 640, 3))
-        grabber.release()
+#         self.assertIsInstance(frame, np.ndarray)
+#         self.assertEqual(frame.shape, (480, 640, 3))
+#         grabber.release()
 
-    def test_invalid_file(self):
-        """Test initialization with invalid file."""
-        config = self.base_config_mp4.copy()
-        config["id"]["filename"] = "nonexistent.mp4"
+#     def test_invalid_file(self):
+#         """Test initialization with invalid file."""
+#         config = self.base_config_mp4.copy()
+#         config["id"]["filename"] = "nonexistent.mp4"
 
-        with self.assertRaises(ValueError):
-            FileStreamFrameGrabber(config)
+#         with self.assertRaises(ValueError):
+#             FileStreamFrameGrabber(config)
 
-    def test_invalid_resolution_option(self):
-        """Test that setting resolution raises an error for both formats."""
-        for config in [self.base_config_mp4, self.base_config_mjpeg]:
-            config_with_res = config.copy()
-            config_with_res["options"] = {"resolution": {"width": 1920, "height": 1080}}
+#     def test_invalid_resolution_option(self):
+#         """Test that setting resolution raises an error for both formats."""
+#         for config in [self.base_config_mp4, self.base_config_mjpeg]:
+#             config_with_res = config.copy()
+#             config_with_res["options"] = {"resolution": {"width": 1920, "height": 1080}}
 
-            grabber = FileStreamFrameGrabber(config_with_res)
-            with self.assertRaises(ValueError):
-                grabber.apply_options(config_with_res["options"])
-            grabber.release()
+#             grabber = FileStreamFrameGrabber(config_with_res)
+#             with self.assertRaises(ValueError):
+#                 grabber.apply_options(config_with_res["options"])
+#             grabber.release()

--- a/test/test_framegrab_with_filestream.py
+++ b/test/test_framegrab_with_filestream.py
@@ -1,138 +1,138 @@
-# import os
-# import shutil
-# import tempfile
-# import unittest
+import os
+import shutil
+import tempfile
+import unittest
 
-# import cv2
-# import numpy as np
+import cv2
+import numpy as np
 
-# from framegrab.grabber import FileStreamFrameGrabber
+from framegrab.grabber import FileStreamFrameGrabber
 
 
-# class TestFileStreamFrameGrabber(unittest.TestCase):
-#     def setUp(self):
-#         """Create temporary video files for testing."""
+class TestFileStreamFrameGrabber(unittest.TestCase):
+    def setUp(self):
+        """Create temporary video files for testing."""
 
-#         self.temp_dir = tempfile.mkdtemp()
-#         self.mp4_path = os.path.join(self.temp_dir, "test_video.mp4")
-#         self.mjpeg_path = os.path.join(self.temp_dir, "test_video.mjpeg")
+        self.temp_dir = tempfile.mkdtemp()
+        self.mp4_path = os.path.join(self.temp_dir, "test_video.mp4")
+        self.mjpeg_path = os.path.join(self.temp_dir, "test_video.mjpeg")
 
-#         # Create test videos
-#         width, height = 640, 480
-#         fps = 30.0
+        # Create test videos
+        width, height = 640, 480
+        fps = 30.0
 
-#         # Create MP4 test video
-#         fourcc_mp4 = cv2.VideoWriter.fourcc(*"mp4v")
-#         writer_mp4 = cv2.VideoWriter(self.mp4_path, fourcc_mp4, fps, (width, height))
+        # Create MP4 test video
+        fourcc_mp4 = cv2.VideoWriter.fourcc(*"mp4v")
+        writer_mp4 = cv2.VideoWriter(self.mp4_path, fourcc_mp4, fps, (width, height))
 
-#         # Create MJPEG test video
-#         fourcc_mjpeg = cv2.VideoWriter.fourcc(*"MJPG")
-#         writer_mjpeg = cv2.VideoWriter(
-#             self.mjpeg_path, fourcc_mjpeg, fps, (width, height)
-#         )
+        # Create MJPEG test video
+        fourcc_mjpeg = cv2.VideoWriter.fourcc(*"MJPG")
+        writer_mjpeg = cv2.VideoWriter(
+            self.mjpeg_path, fourcc_mjpeg, fps, (width, height)
+        )
 
-#         # Generate 1 second of frames for both videos
-#         for _ in range(int(fps)):
-#             frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
-#             writer_mp4.write(frame)
-#             writer_mjpeg.write(frame)
+        # Generate 1 second of frames for both videos
+        for _ in range(int(fps)):
+            frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+            writer_mp4.write(frame)
+            writer_mjpeg.write(frame)
 
-#         writer_mp4.release()
-#         writer_mjpeg.release()
+        writer_mp4.release()
+        writer_mjpeg.release()
 
-#         self.base_config_mp4 = {
-#             "input_type": "file",
-#             "name": "test_video_mp4",
-#             "id": {"filename": self.mp4_path},
-#         }
+        self.base_config_mp4 = {
+            "input_type": "file",
+            "name": "test_video_mp4",
+            "id": {"filename": self.mp4_path},
+        }
 
-#         self.base_config_mjpeg = {
-#             "input_type": "file",
-#             "name": "test_video_mjpeg",
-#             "id": {"filename": self.mjpeg_path},
-#         }
+        self.base_config_mjpeg = {
+            "input_type": "file",
+            "name": "test_video_mjpeg",
+            "id": {"filename": self.mjpeg_path},
+        }
 
-#     def tearDown(self):
-#         """Clean up temporary files."""
-#         shutil.rmtree(self.temp_dir)
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.temp_dir)
 
-#     def test_init_success_mp4(self):
-#         """Test successful initialization with MP4."""
-#         grabber = FileStreamFrameGrabber(self.base_config_mp4)
-#         self.assertEqual(grabber.fps_source, 30.0)
-#         self.assertFalse(grabber.should_drop_frames)
-#         grabber.release()
+    def test_init_success_mp4(self):
+        """Test successful initialization with MP4."""
+        grabber = FileStreamFrameGrabber(self.base_config_mp4)
+        self.assertEqual(grabber.fps_source, 30.0)
+        self.assertFalse(grabber.should_drop_frames)
+        grabber.release()
 
-#     def test_init_success_mjpeg(self):
-#         """Test successful initialization with MJPEG."""
-#         with FileStreamFrameGrabber(self.base_config_mjpeg) as grabber:
-#             # MJPEG files have variable frame rates and also the FPS that cv2 returns is not accurate
-#             self.assertGreater(grabber.fps_source, 20.0)
-#             self.assertLess(grabber.fps_source, 40.0)
-#             self.assertFalse(grabber.should_drop_frames)
+    def test_init_success_mjpeg(self):
+        """Test successful initialization with MJPEG."""
+        with FileStreamFrameGrabber(self.base_config_mjpeg) as grabber:
+            # MJPEG files have variable frame rates and also the FPS that cv2 returns is not accurate
+            self.assertGreater(grabber.fps_source, 20.0)
+            self.assertLess(grabber.fps_source, 40.0)
+            self.assertFalse(grabber.should_drop_frames)
 
-#     def test_init_with_fps_target_mp4(self):
-#         """Test initialization with FPS target for MP4."""
-#         target_fps = 15.0
-#         config = self.base_config_mp4.copy()
-#         config["options"] = {"max_fps": target_fps}
+    def test_init_with_fps_target_mp4(self):
+        """Test initialization with FPS target for MP4."""
+        target_fps = 15.0
+        config = self.base_config_mp4.copy()
+        config["options"] = {"max_fps": target_fps}
 
-#         grabber = FileStreamFrameGrabber(config)
-#         self.assertTrue(grabber.should_drop_frames)
-#         self.assertEqual(grabber.fps_target, target_fps)
-#         grabber.release()
+        grabber = FileStreamFrameGrabber(config)
+        self.assertTrue(grabber.should_drop_frames)
+        self.assertEqual(grabber.fps_target, target_fps)
+        grabber.release()
 
-#     def test_init_with_fps_target_mjpeg(self):
-#         """Test initialization with FPS target for MJPEG."""
-#         target_fps = 15.0
-#         config = self.base_config_mjpeg.copy()
-#         config["options"] = {"max_fps": target_fps}
+    def test_init_with_fps_target_mjpeg(self):
+        """Test initialization with FPS target for MJPEG."""
+        target_fps = 15.0
+        config = self.base_config_mjpeg.copy()
+        config["options"] = {"max_fps": target_fps}
 
-#         grabber = FileStreamFrameGrabber(config)
-#         self.assertTrue(grabber.should_drop_frames)
-#         self.assertEqual(grabber.fps_target, target_fps)
-#         grabber.release()
+        grabber = FileStreamFrameGrabber(config)
+        self.assertTrue(grabber.should_drop_frames)
+        self.assertEqual(grabber.fps_target, target_fps)
+        grabber.release()
 
-#     def test_init_without_filename(self):
-#         """Test initialization fails without filename."""
-#         config = {"input_type": "file", "name": "test_video"}
+    def test_init_without_filename(self):
+        """Test initialization fails without filename."""
+        config = {"input_type": "file", "name": "test_video"}
 
-#         with self.assertRaises(ValueError):
-#             FileStreamFrameGrabber(config)
+        with self.assertRaises(ValueError):
+            FileStreamFrameGrabber(config)
 
-#     def test_grab_frame_mp4(self):
-#         """Test frame grabbing from MP4."""
-#         grabber = FileStreamFrameGrabber(self.base_config_mp4)
-#         frame = grabber.grab()
+    def test_grab_frame_mp4(self):
+        """Test frame grabbing from MP4."""
+        grabber = FileStreamFrameGrabber(self.base_config_mp4)
+        frame = grabber.grab()
 
-#         self.assertIsInstance(frame, np.ndarray)
-#         self.assertEqual(frame.shape, (480, 640, 3))
-#         grabber.release()
+        self.assertIsInstance(frame, np.ndarray)
+        self.assertEqual(frame.shape, (480, 640, 3))
+        grabber.release()
 
-#     def test_grab_frame_mjpeg(self):
-#         """Test frame grabbing from MJPEG."""
-#         grabber = FileStreamFrameGrabber(self.base_config_mjpeg)
-#         frame = grabber.grab()
+    def test_grab_frame_mjpeg(self):
+        """Test frame grabbing from MJPEG."""
+        grabber = FileStreamFrameGrabber(self.base_config_mjpeg)
+        frame = grabber.grab()
 
-#         self.assertIsInstance(frame, np.ndarray)
-#         self.assertEqual(frame.shape, (480, 640, 3))
-#         grabber.release()
+        self.assertIsInstance(frame, np.ndarray)
+        self.assertEqual(frame.shape, (480, 640, 3))
+        grabber.release()
 
-#     def test_invalid_file(self):
-#         """Test initialization with invalid file."""
-#         config = self.base_config_mp4.copy()
-#         config["id"]["filename"] = "nonexistent.mp4"
+    def test_invalid_file(self):
+        """Test initialization with invalid file."""
+        config = self.base_config_mp4.copy()
+        config["id"]["filename"] = "nonexistent.mp4"
 
-#         with self.assertRaises(ValueError):
-#             FileStreamFrameGrabber(config)
+        with self.assertRaises(ValueError):
+            FileStreamFrameGrabber(config)
 
-#     def test_invalid_resolution_option(self):
-#         """Test that setting resolution raises an error for both formats."""
-#         for config in [self.base_config_mp4, self.base_config_mjpeg]:
-#             config_with_res = config.copy()
-#             config_with_res["options"] = {"resolution": {"width": 1920, "height": 1080}}
+    def test_invalid_resolution_option(self):
+        """Test that setting resolution raises an error for both formats."""
+        for config in [self.base_config_mp4, self.base_config_mjpeg]:
+            config_with_res = config.copy()
+            config_with_res["options"] = {"resolution": {"width": 1920, "height": 1080}}
 
-#             grabber = FileStreamFrameGrabber(config_with_res)
-#             with self.assertRaises(ValueError):
-#                 grabber.apply_options(config_with_res["options"])
-#             grabber.release()
+            grabber = FileStreamFrameGrabber(config_with_res)
+            with self.assertRaises(ValueError):
+                grabber.apply_options(config_with_res["options"])
+            grabber.release()

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -220,11 +220,10 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         
         `create_grabbers` should return a list of of all valid grabbers that it was able to create.
         """
-        1 / 0
         configs = [
             {
                 "id": {
-                    "serial_number": "123"
+                    "serial_number": "123" # valid 'mock' camera
                 },
                 "name": "Mock Camera 1",
                 "input_type": "mock",
@@ -238,7 +237,7 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
             },
                         {
                 "id": {
-                    "serial_number": "456"
+                    "serial_number": "456" # valid 'mock' camera
                 },
                 "name": "Mock Camera 2",
                 "input_type": "mock",

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -214,41 +214,41 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         assert new_config == config
         
         
-    # def test_create_grabbers_with_one_invalid_config(self):
-    #     """
-    #     Defines a list of camera configurations, where one of the configurations is invalid.
+    def test_create_grabbers_with_one_invalid_config(self):
+        """
+        Defines a list of camera configurations, where one of the configurations is invalid.
         
-    #     `create_grabbers` should return a list of of all valid grabbers that it was able to create.
-    #     """
-    #     configs = [
-    #         {
-    #             "id": {
-    #                 "serial_number": "123" # valid 'mock' camera
-    #             },
-    #             "name": "Mock Camera 1",
-    #             "input_type": "mock",
-    #         },
-    #         {
-    #             "id": {
-    #                 "rtsp_url": "rtsp://INVALID:INVALID@0.0.0.0:0" # invalid rtsp url
-    #                 },
-    #             "name": "Invalid RTSP Camera",
-    #             "input_type": "rtsp",
-    #         },
-    #                     {
-    #             "id": {
-    #                 "serial_number": "456" # valid 'mock' camera
-    #             },
-    #             "name": "Mock Camera 2",
-    #             "input_type": "mock",
-    #         },
-    #     ]
+        `create_grabbers` should return a list of of all valid grabbers that it was able to create.
+        """
+        configs = [
+            {
+                "id": {
+                    "serial_number": "123" # valid 'mock' camera
+                },
+                "name": "Mock Camera 1",
+                "input_type": "mock",
+            },
+            {
+                "id": {
+                    "rtsp_url": "rtsp://INVALID:INVALID@0.0.0.0:0" # invalid rtsp url
+                    },
+                "name": "Invalid RTSP Camera",
+                "input_type": "rtsp",
+            },
+                        {
+                "id": {
+                    "serial_number": "456" # valid 'mock' camera
+                },
+                "name": "Mock Camera 2",
+                "input_type": "mock",
+            },
+        ]
         
-    #     grabbers = FrameGrabber.create_grabbers(configs)
-    #     for grabber in grabbers.values():
-    #         grabber.release()
+        grabbers = FrameGrabber.create_grabbers(configs)
+        for grabber in grabbers.values():
+            grabber.release()
         
-    #     assert len(grabbers) == 2
+        assert len(grabbers) == 2
         
         
         

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -214,42 +214,42 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         assert new_config == config
         
         
-    def test_create_grabbers_with_one_invalid_config(self):
-        """
-        Defines a list of camera configurations, where one of the configurations is invalid.
+    # def test_create_grabbers_with_one_invalid_config(self):
+    #     """
+    #     Defines a list of camera configurations, where one of the configurations is invalid.
         
-        `create_grabbers` should return a list of of all valid grabbers that it was able to create.
-        """
-        configs = [
-            {
-                "id": {
-                    "serial_number": "123" # valid 'mock' camera
-                },
-                "name": "Mock Camera 1",
-                "input_type": "mock",
-            },
-            {
-                "id": {
-                    "rtsp_url": "rtsp://INVALID:INVALID@0.0.0.0:0" # invalid rtsp url
-                    },
-                "name": "Invalid RTSP Camera",
-                "input_type": "rtsp",
-            },
-                        {
-                "id": {
-                    "serial_number": "456" # valid 'mock' camera
-                },
-                "name": "Mock Camera 2",
-                "input_type": "mock",
-            },
-        ]
+    #     `create_grabbers` should return a list of of all valid grabbers that it was able to create.
+    #     """
+    #     configs = [
+    #         {
+    #             "id": {
+    #                 "serial_number": "123" # valid 'mock' camera
+    #             },
+    #             "name": "Mock Camera 1",
+    #             "input_type": "mock",
+    #         },
+    #         {
+    #             "id": {
+    #                 "rtsp_url": "rtsp://INVALID:INVALID@0.0.0.0:0" # invalid rtsp url
+    #                 },
+    #             "name": "Invalid RTSP Camera",
+    #             "input_type": "rtsp",
+    #         },
+    #                     {
+    #             "id": {
+    #                 "serial_number": "456" # valid 'mock' camera
+    #             },
+    #             "name": "Mock Camera 2",
+    #             "input_type": "mock",
+    #         },
+    #     ]
         
-        grabbers = FrameGrabber.create_grabbers(configs)
+    #     grabbers = FrameGrabber.create_grabbers(configs)
+    #     for grabber in grabbers.values():
+    #         grabber.release()
         
-        assert len(grabbers) == 2
+    #     assert len(grabbers) == 2
         
-        for grabber in grabbers.values():
-            grabber.release()
         
         
            

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -248,5 +248,8 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         
         assert len(grabbers) == 2
         
+        for grabber in grabbers.values():
+            grabber.release()
+        
         
            

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -218,7 +218,7 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         """
         Defines a list of camera configurations, where one of the configurations is invalid.
         
-        `create_grabbers` should return a list of of all valid grabbers that it was able to create.
+        `create_grabbers` should return all valid grabbers that it was able to create.
         """
         configs = [
             {

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -212,3 +212,42 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         new_config = RTSPFrameGrabber._substitute_rtsp_password(config)
 
         assert new_config == config
+        
+        
+    def test_create_grabbers_with_one_invalid_config(self):
+        """
+        Defines a list of camera configurations, where one of the configurations is invalid.
+        
+        `create_grabbers` should return a list of of all valid grabbers that it was able to create.
+        """
+        1 / 0
+        configs = [
+            {
+                "id": {
+                    "serial_number": "123"
+                },
+                "name": "Mock Camera 1",
+                "input_type": "mock",
+            },
+            {
+                "id": {
+                    "rtsp_url": "rtsp://INVALID:INVALID@0.0.0.0:0" # invalid rtsp url
+                    },
+                "name": "Invalid RTSP Camera",
+                "input_type": "rtsp",
+            },
+                        {
+                "id": {
+                    "serial_number": "456"
+                },
+                "name": "Mock Camera 2",
+                "input_type": "mock",
+            },
+        ]
+        
+        grabbers = FrameGrabber.create_grabbers(configs)
+        
+        assert len(grabbers) == 2
+        
+        
+           


### PR DESCRIPTION
Previously, if even one grabber config was invalid (wrong rtsp url, camera was unplugged, etc.) in `create_grabbers`, an exception would be raised.

I do not believe this is correct behavior, and it is causing problems on the URCap: if one of the user-configured cameras cannot connect for whatever reason, all of the configured cameras fail to connect. This PR changes the behavior so that a warning is logged, and all cameras that successfully connected are returned. 

I debated making this change for a while, because I thought it might lead to silent failures, but I realized that the client can just compare the list of configs to the resulting grabbers to learn if there were any connection failures (which is what I plan to do on the URCap).