### PR TITLE
Fix framegrab bug passing dictionary directly into the constructor

### DIFF
--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -81,7 +81,7 @@ class FrameGrabber(ABC):
     unnamed_grabber_count = 0
     config: FrameGrabberConfig
 
-    def __init__(self, config: FrameGrabberConfig | dict):
+    def __init__(self, config: Union[FrameGrabberConfig, dict]):
         """To create a FrameGrabber object with the generic FrameGrabber class or with a config dict, use create_grabber()"""
         if isinstance(config, dict):
             config = self.config_class.from_framegrab_config_dict(config)

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -79,11 +79,12 @@ NOISE = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)  # in case a ca
 class FrameGrabber(ABC):
     # for naming FrameGrabber objects that have no user-defined name
     unnamed_grabber_count = 0
-
     config: FrameGrabberConfig
 
-    def __init__(self, config: FrameGrabberConfig):
+    def __init__(self, config: FrameGrabberConfig | dict):
         """To create a FrameGrabber object with the generic FrameGrabber class or with a config dict, use create_grabber()"""
+        if isinstance(config, dict):
+            config = self.config_class.from_framegrab_config_dict(config)
         if not isinstance(config, self.config_class):
             raise TypeError(
                 f"Expected config to be of type {self.config_class.__name__}, but got {type(config).__name__}"

--- a/test/test_all_grabber_types_generic.py
+++ b/test/test_all_grabber_types_generic.py
@@ -104,7 +104,8 @@ class TestAllGrabberTypes(unittest.TestCase):
         grabber_from_class = grabber_class(grabber.config.to_framegrab_config_dict())
         new_frame = grabber_from_class.grab()
         np.testing.assert_array_equal(new_frame, expected_frame)
-        
+        grabber_from_class.release()
+
     @patch('framegrab.grabber.GenericUSBFrameGrabber._find_cameras')
     @patch('cv2.VideoCapture')
     def test_generic_usb_grabber(self, mock_video_capture, mock_find_cameras):

--- a/test/test_all_grabber_types_generic.py
+++ b/test/test_all_grabber_types_generic.py
@@ -99,6 +99,12 @@ class TestAllGrabberTypes(unittest.TestCase):
         self.assertEqual(new_grabber.config.digital_zoom, 4)
         new_grabber.release()
 
+        # test creating grabber directly from class with a dictionary
+        grabber_class = type(grabber)
+        grabber_from_class = grabber_class(grabber.config.to_framegrab_config_dict())
+        new_frame = grabber_from_class.grab()
+        np.testing.assert_array_equal(new_frame, expected_frame)
+        
     @patch('framegrab.grabber.GenericUSBFrameGrabber._find_cameras')
     @patch('cv2.VideoCapture')
     def test_generic_usb_grabber(self, mock_video_capture, mock_find_cameras):


### PR DESCRIPTION
The pydantic changes didn't allow the user to directly pass the config dictionary into the constructor. We want the changes to be backwards compatible so I fixed this. This fixes the bug in the readme creating a youtube grabber.