### PR TITLE
Output contiguous arrays when rotating frames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "framegrab"
-version = "0.12.0"
+version = "0.12.1"
 description = "Easily grab frames from cameras or streams"
 authors = ["Groundlight <info@groundlight.ai>"]
 license = "MIT"

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -1,5 +1,4 @@
 import logging
-from multiprocessing import Value
 import platform
 import re
 import subprocess

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -4,7 +4,6 @@ import re
 import subprocess
 import time
 from abc import ABC, abstractmethod
-from multiprocessing import Value
 from threading import Lock, Thread
 from typing import Dict, List, Optional, Union
 

--- a/src/framegrab/grabber.py
+++ b/src/framegrab/grabber.py
@@ -1,4 +1,5 @@
 import logging
+from multiprocessing import Value
 import platform
 import re
 import subprocess
@@ -480,14 +481,27 @@ class FrameGrabber(ABC):
         return frame
 
     def _rotate(self, frame: np.ndarray) -> np.ndarray:
-        """Rotates the provided frame a specified number of 90 degree rotations clockwise"""
+        """Rotates the provided frame a specified number of 90 degree rotations counterclockwise"""
 
         num_90_deg_rotations = self.config.num_90_deg_rotations
 
-        for n in range(num_90_deg_rotations):
-            frame = np.rot90(frame)
+        if num_90_deg_rotations == 0: # no rotation
+            return frame
 
-        return frame
+        # Calculate rotation
+        if num_90_deg_rotations == 1:
+            rotate_code = cv2.ROTATE_90_COUNTERCLOCKWISE
+        elif num_90_deg_rotations == 2:
+            rotate_code = cv2.ROTATE_180
+        elif num_90_deg_rotations == 3:
+            rotate_code = cv2.ROTATE_90_CLOCKWISE
+        else:
+            raise ValueError(
+                f'Invalid value for num_90_deg_rotations. Got: {num_90_deg_rotations}. Expected 0, 1, 2, or 3.'
+            )
+        
+        # Apply the rotation
+        return cv2.rotate(frame, rotate_code)
 
     def apply_options(self, options: dict) -> None:
         """Update generic options such as crop and zoom as well as

--- a/test/test_framegrab_with_mock_camera.py
+++ b/test/test_framegrab_with_mock_camera.py
@@ -246,6 +246,14 @@ class TestFrameGrabWithMockCamera(unittest.TestCase):
         assert len(grabbers) == 2
 
     def test_rotating_frame_outputs_contiguous_array(self):
+        """Test that all rotation operations produce contiguous arrays.
+    
+        Rotates frames by 0, 90, 180, and 270 degrees and verifies that:
+        1. The resulting arrays are C_CONTIGUOUS for optimal memory layout
+        2. OpenCV operations like cv2.line() work without errors
+        
+        This ensures rotated frames maintain performance and compatibility.
+        """
         for n in range(0, 4):
             config = MockFrameGrabberConfig(
                 num_90_deg_rotations=n


### PR DESCRIPTION
When performing rotation operations, framegrab returns a non-contiguous array. For many uses, this is okay, but I realized functions like cv2.line will fail on this.

I change the rotation operation from `np.rot90` to `cv2.rotate`. This avoids the non-contiguous problem and is also more performant.  